### PR TITLE
feat: Next.js /api/sheetsエンドポイントをNestJS GraphQLに移植

### DIFF
--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({
   dialect: 'mysql',
-  schema: './src/db/schema.ts',
-  out: './src/db',
+  schema: './src/database/schema/index.ts',
+  out: './src/database',
   dbCredentials: {
     user: process.env.DB_USER,
     password: process.env.DB_PASS,

--- a/apps/api/src/infrastructure/repositories/sheets.repository.ts
+++ b/apps/api/src/infrastructure/repositories/sheets.repository.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { eq, desc } from 'drizzle-orm';
+import { eq, desc, and } from 'drizzle-orm';
 import { sheets } from '../../database/schema/sheets.schema';
 import { DrizzleDb } from '../../database/types';
 import { INJECTION_TOKENS } from '../../constants/injection-tokens';
@@ -16,5 +16,64 @@ export class SheetsRepository {
       .from(sheets)
       .where(eq(sheets.userId, userId))
       .orderBy(desc(sheets.order));
+  }
+
+  async findByUserIdAndName(
+    userId: string,
+    name: string,
+  ): Promise<Sheet | undefined> {
+    const results = await this.db
+      .select()
+      .from(sheets)
+      .where(and(eq(sheets.userId, userId), eq(sheets.name, name)))
+      .limit(1);
+    return results[0];
+  }
+
+  async findLastByUserId(userId: string): Promise<Sheet | undefined> {
+    const results = await this.db
+      .select()
+      .from(sheets)
+      .where(eq(sheets.userId, userId))
+      .orderBy(desc(sheets.order))
+      .limit(1);
+    return results[0];
+  }
+
+  async create(data: {
+    userId: string;
+    name: string;
+    order: number;
+  }): Promise<Sheet> {
+    const result = await this.db.insert(sheets).values(data);
+    const insertId = result[0].insertId;
+    const created = await this.db
+      .select()
+      .from(sheets)
+      .where(eq(sheets.id, insertId))
+      .limit(1);
+    return created[0];
+  }
+
+  async update(
+    userId: string,
+    oldName: string,
+    newName: string,
+  ): Promise<Sheet> {
+    await this.db
+      .update(sheets)
+      .set({ name: newName, updated: new Date() })
+      .where(and(eq(sheets.userId, userId), eq(sheets.name, oldName)));
+    const updated = await this.findByUserIdAndName(userId, newName);
+    if (!updated) {
+      throw new Error('Sheet not found after update');
+    }
+    return updated;
+  }
+
+  async delete(userId: string, name: string): Promise<void> {
+    await this.db
+      .delete(sheets)
+      .where(and(eq(sheets.userId, userId), eq(sheets.name, name)));
   }
 }

--- a/apps/api/src/modules/sheets/dto/create-sheet.input.ts
+++ b/apps/api/src/modules/sheets/dto/create-sheet.input.ts
@@ -1,0 +1,7 @@
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
+export class CreateSheetInput {
+  @Field()
+  name: string;
+}

--- a/apps/api/src/modules/sheets/dto/delete-sheet.input.ts
+++ b/apps/api/src/modules/sheets/dto/delete-sheet.input.ts
@@ -1,0 +1,7 @@
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
+export class DeleteSheetInput {
+  @Field()
+  name: string;
+}

--- a/apps/api/src/modules/sheets/dto/sheet.object.ts
+++ b/apps/api/src/modules/sheets/dto/sheet.object.ts
@@ -10,7 +10,7 @@ import {
 export class SheetObject {
   /** 主キー ─ 数値なら Int でも OK。一般的には ID 推奨 */
   @Field(() => ID)
-  id: number;
+  id: string;
 
   @Field()
   name: string;

--- a/apps/api/src/modules/sheets/dto/update-sheet.input.ts
+++ b/apps/api/src/modules/sheets/dto/update-sheet.input.ts
@@ -1,0 +1,10 @@
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
+export class UpdateSheetInput {
+  @Field()
+  oldName: string;
+
+  @Field()
+  newName: string;
+}

--- a/apps/api/src/modules/sheets/sheets.module.ts
+++ b/apps/api/src/modules/sheets/sheets.module.ts
@@ -3,9 +3,10 @@ import { SheetsResolver } from './sheets.resolver';
 import { SheetsService } from './sheets.service';
 import { SheetsUseCaseModule } from './usecase/usecase.module';
 import { AuthModule } from '../../auth/auth.module';
+import { SheetsRepository } from '../../infrastructure/repositories/sheets.repository';
 
 @Module({
   imports: [AuthModule, SheetsUseCaseModule],
-  providers: [SheetsResolver, SheetsService],
+  providers: [SheetsResolver, SheetsService, SheetsRepository],
 })
 export class SheetsModule {}

--- a/apps/api/src/modules/sheets/sheets.module.ts
+++ b/apps/api/src/modules/sheets/sheets.module.ts
@@ -4,9 +4,10 @@ import { SheetsService } from './sheets.service';
 import { SheetsUseCaseModule } from './usecase/usecase.module';
 import { AuthModule } from '../../auth/auth.module';
 import { SheetsRepository } from '../../infrastructure/repositories/sheets.repository';
+import { DatabaseModule } from '../../database/database.module';
 
 @Module({
-  imports: [AuthModule, SheetsUseCaseModule],
+  imports: [AuthModule, SheetsUseCaseModule, DatabaseModule],
   providers: [SheetsResolver, SheetsService, SheetsRepository],
 })
 export class SheetsModule {}

--- a/apps/api/src/modules/sheets/sheets.resolver.ts
+++ b/apps/api/src/modules/sheets/sheets.resolver.ts
@@ -1,4 +1,4 @@
-import { Query, Resolver } from '@nestjs/graphql';
+import { Query, Resolver, Mutation, Args } from '@nestjs/graphql';
 import { SheetsResponseDto } from './dto/sheets-response.dto';
 import { SheetsService } from './sheets.service';
 import { GetSheetsUseCase } from './usecase/get-sheets.usecase';
@@ -6,6 +6,9 @@ import { GqlAuthGuard } from '../../auth/gql-auth.guard';
 import { UseGuards } from '@nestjs/common';
 import { CurrentUser } from '../../auth/current-user.decorator';
 import { SheetObject } from './dto/sheet.object';
+import { CreateSheetInput } from './dto/create-sheet.input';
+import { UpdateSheetInput } from './dto/update-sheet.input';
+import { DeleteSheetInput } from './dto/delete-sheet.input';
 
 @Resolver(() => SheetsResponseDto)
 @UseGuards(GqlAuthGuard)
@@ -21,12 +24,41 @@ export class SheetsResolver {
   ): Promise<SheetObject[]> {
     const sheets = await this.getSheetsUseCase.execute(user.id);
     return sheets.map((sheet) => ({
-      id: sheet.id,
+      id: sheet.id.toString(),
       name: sheet.name,
       userId: sheet.userId,
       created: sheet.created ?? undefined,
       updated: sheet.updated ?? undefined,
       order: sheet.order ?? undefined,
     }));
+  }
+
+  @Mutation(() => SheetObject)
+  async createSheet(
+    @CurrentUser() user: { id: string; admin: boolean },
+    @Args('input') input: CreateSheetInput,
+  ): Promise<SheetObject> {
+    return await this.sheetsService.createSheet(user.id, input.name);
+  }
+
+  @Mutation(() => SheetObject)
+  async updateSheet(
+    @CurrentUser() user: { id: string; admin: boolean },
+    @Args('input') input: UpdateSheetInput,
+  ): Promise<SheetObject> {
+    return await this.sheetsService.updateSheet(
+      user.id,
+      input.oldName,
+      input.newName,
+    );
+  }
+
+  @Mutation(() => Boolean)
+  async deleteSheet(
+    @CurrentUser() user: { id: string; admin: boolean },
+    @Args('input') input: DeleteSheetInput,
+  ): Promise<boolean> {
+    await this.sheetsService.deleteSheet(user.id, input.name);
+    return true;
   }
 }

--- a/apps/api/src/modules/sheets/sheets.service.ts
+++ b/apps/api/src/modules/sheets/sheets.service.ts
@@ -1,8 +1,49 @@
 import { Injectable } from '@nestjs/common';
+import { SheetsRepository } from '../../infrastructure/repositories/sheets.repository';
+import { SheetObject } from './dto/sheet.object';
 
 @Injectable()
 export class SheetsService {
-  getSheets(): string {
-    return 'Sheets World!';
+  constructor(private readonly sheetsRepository: SheetsRepository) {}
+
+  async createSheet(userId: string, name: string): Promise<SheetObject> {
+    const lastSheet = await this.sheetsRepository.findLastByUserId(userId);
+    const order = lastSheet ? (lastSheet.order ?? 0) + 1 : 1;
+
+    const created = await this.sheetsRepository.create({
+      userId,
+      name,
+      order,
+    });
+
+    return {
+      id: created.id.toString(),
+      name: created.name,
+      userId: created.userId,
+      created: created.created ?? undefined,
+      updated: created.updated ?? undefined,
+      order: created.order ?? undefined,
+    };
+  }
+
+  async updateSheet(
+    userId: string,
+    oldName: string,
+    newName: string,
+  ): Promise<SheetObject> {
+    const updated = await this.sheetsRepository.update(userId, oldName, newName);
+
+    return {
+      id: updated.id.toString(),
+      name: updated.name,
+      userId: updated.userId,
+      created: updated.created ?? undefined,
+      updated: updated.updated ?? undefined,
+      order: updated.order ?? undefined,
+    };
+  }
+
+  async deleteSheet(userId: string, name: string): Promise<void> {
+    await this.sheetsRepository.delete(userId, name);
   }
 }

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -24,3 +24,22 @@ type Query {
   hello: HelloResponseDto!
   sheets: [SheetObject!]!
 }
+
+type Mutation {
+  createSheet(input: CreateSheetInput!): SheetObject!
+  updateSheet(input: UpdateSheetInput!): SheetObject!
+  deleteSheet(input: DeleteSheetInput!): Boolean!
+}
+
+input CreateSheetInput {
+  name: String!
+}
+
+input UpdateSheetInput {
+  oldName: String!
+  newName: String!
+}
+
+input DeleteSheetInput {
+  name: String!
+}


### PR DESCRIPTION
## Summary
- Next.jsの `/api/sheets` エンドポイントをNestJS GraphQLに移植
- CRUD操作（GET/POST/PUT/DELETE）を全てGraphQL Query/Mutationとして実装
- Drizzle ORMを使用したデータベース操作に統一

## 変更内容
### GraphQL Mutations追加
- `createSheet`: 新規シート作成
- `updateSheet`: シート名更新
- `deleteSheet`: シート削除

### 実装ファイル
- **DTOファイル**: `create-sheet.input.ts`, `update-sheet.input.ts`, `delete-sheet.input.ts`
- **リゾルバー**: `sheets.resolver.ts` にMutation追加
- **サービス**: `sheets.service.ts` にビジネスロジック実装
- **リポジトリ**: `sheets.repository.ts` にDrizzle ORMを使用したCRUD操作追加
- **モジュール**: `sheets.module.ts` にSheetsRepository追加
- **型修正**: `sheet.object.ts` のID型をnumberからstringに変更（GraphQL互換性向上）

## Test plan
- [ ] GraphQL Playgroundで各Mutationの動作確認
- [ ] 既存のsheetsクエリが正常に動作することを確認
- [ ] ユーザー認証が必要なことを確認
- [ ] ユニーク制約とorder自動採番の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)