### PR TITLE
Fix tabs and menu spacing when there are few sheets

### DIFF
--- a/apps/web/src/features/sheet/components/Menu.tsx
+++ b/apps/web/src/features/sheet/components/Menu.tsx
@@ -75,7 +75,7 @@ export const Menu: React.FC<Props> = ({
                 animate="open"
                 exit="closed"
                 variants={variants}
-                className="absolute right-4 z-[1000] m-0 min-w-max list-none overflow-hidden rounded-lg border bg-white bg-clip-padding text-left text-base shadow-lg sm:right-20"
+                className="absolute right-0 z-[1000] m-0 min-w-max list-none overflow-hidden rounded-lg border bg-white bg-clip-padding text-left text-base shadow-lg"
               >
                 <li className="border-bottom-1 flex items-center border px-4 py-2 hover:bg-neutral-100">
                   <AiOutlineFileAdd className="mr-2 h-[24px] w-[24px] text-slate-300" />

--- a/apps/web/src/features/sheet/components/SheetPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetPage.tsx
@@ -78,13 +78,9 @@ export const SheetPage: React.FC<Props> = ({
     return (
       <Container>
         <NextSeo title={`${username}/${year} | kidoku`} />
-        <div className="flex items-center">
-          <div className="mb-8 w-[90%] border-b border-gray-200">
-            <Tabs sheets={sheets} value={year} username={username} />
-          </div>
-          <div className="w-[10%]">
-            <Menu currentSheet={year} username={username} />
-          </div>
+        <div className="mb-8 flex items-center border-b border-gray-200">
+          <Tabs sheets={sheets} value={year} username={username} />
+          <Menu currentSheet={year} username={username} />
         </div>
         <div className="p-10 text-center">
           <div className="mb-4 text-2xl font-bold">
@@ -100,12 +96,8 @@ export const SheetPage: React.FC<Props> = ({
     <Container className="mb-12">
       <NextSeo title={`${username}/${year} | kidoku`} />
       <div className="fixed left-0 top-[53px] z-10 flex w-full items-center bg-white sm:top-[54px] sm:px-32">
-        <div className="w-[90%] pr-4">
-          <Tabs sheets={sheets} value={year} username={username} />
-        </div>
-        <div className="w-[10%]">
-          <Menu currentSheet={year} username={username} />
-        </div>
+        <Tabs sheets={sheets} value={year} username={username} />
+        <Menu currentSheet={year} username={username} />
       </div>
 
       <div className="mt-32 text-center">

--- a/apps/web/src/features/sheet/components/SheetTotal/SheetTotalPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetTotal/SheetTotalPage.tsx
@@ -48,16 +48,12 @@ export const SheetTotalPage: React.FC<Props> = ({
     <Container>
       <NextSeo title={`${username}/Total | kidoku`} />
       <div className="fixed left-0 top-[53px] z-10 flex w-full items-center bg-white sm:top-[54px] sm:px-32">
-        <div className="w-[90%] pr-4">
-          <Tabs sheets={sheets} value="total" username={username} />
-        </div>
-        <div className="w-[10%]">
-          <Menu
-            currentSheet="total"
-            username={username}
-            activate={{ edit: false, delete: false }}
-          />
-        </div>
+        <Tabs sheets={sheets} value="total" username={username} />
+        <Menu
+          currentSheet="total"
+          username={username}
+          activate={{ edit: false, delete: false }}
+        />
       </div>
       <div className="mb-10 mt-32 text-center">
         <TitleWithLine text="累計読書数" />

--- a/apps/web/src/features/sheet/components/Tabs.tsx
+++ b/apps/web/src/features/sheet/components/Tabs.tsx
@@ -22,6 +22,7 @@ export const Tabs: React.FC<Props> = ({ value, sheets, username }) => {
 
   return (
     <div className="no-scrollbar flex items-center justify-start overflow-x-auto">
+      <div className="flex items-center">
       <button
         className={twMerge(
           'flex max-h-11 items-center justify-between whitespace-nowrap px-8 py-3 text-center text-sm uppercase text-gray-600 duration-300 ease-in hover:bg-gray-100',
@@ -55,6 +56,7 @@ export const Tabs: React.FC<Props> = ({ value, sheets, username }) => {
           {sheet}
         </button>
       ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- シートが少ない時にタブと三点メニューの間隔が離れすぎる問題を修正
- ドロップダウンメニューの位置をボタンに近づけるよう調整
- SheetPageとSheetTotalPageの両方で一貫したレイアウト修正を適用

## Changes
- `justify-between`と`flex-1`を削除してタブとメニューの自然な配置を実現
- タブボタンを`flex`コンテナでグループ化
- ドロップダウンメニューの`right-4 sm:right-20`を`right-0`に変更
- 固定幅指定を削除してより柔軟なレイアウトを実装

## Test plan
- [ ] シートが少ない場合（1-2個）でタブとメニューの間隔が適切であることを確認
- [ ] シートが多い場合でも正常に動作することを確認
- [ ] ドロップダウンメニューが三点ボタンの直下に表示されることを確認
- [ ] SheetPageとSheetTotalPageの両方で修正が適用されていることを確認
- [ ] レスポンシブデザインが正常に動作することを確認

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)