### PR TITLE
feat: TiDBクラウド接続時のSSL設定を自動判定する機能を追加

### DIFF
--- a/apps/api/src/database/database.providers.ts
+++ b/apps/api/src/database/database.providers.ts
@@ -7,13 +7,26 @@ import { INJECTION_TOKENS } from '../constants/injection-tokens';
 export const DatabaseProvider = {
   provide: INJECTION_TOKENS.DRIZZLE,
   useFactory: (configService: ConfigService) => {
-    const pool = mysql.createPool({
-      host: configService.get<string>('DB_HOST'),
+    const dbHost = configService.get<string>('DB_HOST');
+    const isProduction = dbHost && dbHost.includes('tidbcloud.com');
+
+    const poolConfig: mysql.PoolOptions = {
+      host: dbHost,
       port: configService.get<number>('DB_PORT'),
       user: configService.get<string>('DB_USER'),
       password: configService.get<string>('DB_PASS'),
       database: configService.get<string>('DB_NAME'),
-    });
+    };
+
+    // 本番環境（TiDBクラウド）の場合のみSSL設定を追加
+    if (isProduction) {
+      poolConfig.ssl = {
+        rejectUnauthorized: true,
+        minVersion: 'TLSv1.2',
+      };
+    }
+
+    const pool = mysql.createPool(poolConfig);
 
     return drizzle(pool, { schema, mode: 'default' });
   },


### PR DESCRIPTION
本番環境（TiDBクラウド）とローカル環境でSSL設定を自動的に切り替えるように改善しました。
ホスト名に'tidbcloud.com'が含まれる場合は自動的にSSL接続を有効化します。

🤖 Generated with [Claude Code](https://claude.ai/code)