### PR TITLE
fix: 書籍詳細ページのSSRエラーを修正 #27

### DIFF
--- a/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
@@ -144,7 +144,7 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
       <CheckoutModal
         open={open}
         onClose={() => setOpen(false)}
-        returnUrl={`${window.location.origin}/books/${book.id}`}
+        returnUrl={returnUrl()}
         purchaseText="書籍を購入"
       />
     </div>


### PR DESCRIPTION
## Summary
- 書籍詳細ページ(/books/[bookId])をリロードした際の500エラーを修正
- `window.location.origin`の直接参照をやめ、環境変数を使用するように変更

## 問題
フルページで本の詳細ページを開いた後、リロードすると`ReferenceError: window is not defined`エラーが発生し、500エラーとなっていました。

## 原因
`BookDetailReadModal`コンポーネントで`window.location.origin`を直接参照していたため、サーバーサイドレンダリング時にエラーが発生していました。

## 修正内容
- `returnUrl={window.location.origin/books/${book.id}}` → `returnUrl={returnUrl()}`に変更
- 既存の`returnUrl()`関数は環境変数`NEXT_PUBLIC_HOST`を使用しているため、SSR時でも安全に動作します

## Test plan
- [ ] `/books/[bookId]`ページを直接開く
- [ ] ページをリロードしてもエラーが発生しないことを確認
- [ ] メモの購入モーダルが正常に動作することを確認

Fixes #27

🤖 Generated with [Claude Code](https://claude.ai/code)