### PR TITLE
fix: サイドバーから「統計」メニュー項目を削除

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -125,12 +125,6 @@ export const Sidebar: React.FC = () => {
         isActive: isSheetsPage,
       },
       {
-        name: '統計',
-        href: session ? `/${session.user.name}/sheets/total` : '/',
-        icon: AiOutlinePieChart,
-        isActive: isTotalPage,
-      },
-      {
         name: '設定',
         href: '/settings/profile',
         icon: AiOutlineSetting,

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -8,7 +8,6 @@ import { openNavSidebarAtom } from '@/store/modal/atom'
 import {
   AiOutlineHome,
   AiOutlineBook,
-  AiOutlinePieChart,
   AiOutlineSetting,
   AiOutlineClose,
 } from 'react-icons/ai'
@@ -108,7 +107,6 @@ export const Sidebar: React.FC = () => {
     const isHomePage = router.pathname === '/'
     const isSheetsPage =
       router.pathname.includes('/sheets') && !router.pathname.includes('/total')
-    const isTotalPage = router.pathname.includes('/total')
     const isSettingsPage = router.pathname.includes('/settings')
 
     return [


### PR DESCRIPTION
## Summary
- サイドバーメニューから「統計」項目を削除
- 統計ページ自体は残しており、直接URLアクセスは可能
- 未使用変数 `isTotalPage` も削除

## Test plan
- [x] サイドバーに「統計」メニューが表示されないことを確認
- [x] 統計ページ（/[user]/sheets/total）に直接アクセスできることを確認
- [x] lint/build エラーがないことを確認

Closes #33

🤖 Generated with [Claude Code](https://claude.ai/code)