### PR TITLE
feat: SheetPageとTotalPageのタブ実装を共通化

### DIFF
--- a/apps/web/src/features/sheet/components/SheetPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetPage.tsx
@@ -92,6 +92,7 @@ export const SheetPage: React.FC<Props> = ({
           sheets={sheets}
           currentSheet={year}
           username={username}
+          variant="simple"
         />
         <div className="p-10 text-center">
           <div className="mb-4 text-2xl font-bold">

--- a/apps/web/src/features/sheet/components/SheetPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetPage.tsx
@@ -4,7 +4,6 @@ import dynamic from 'next/dynamic'
 import { Container } from '@/components/layout/Container'
 import { Book } from '@/types/book'
 import { BarGraph } from './BarGraph'
-import { Tabs } from './Tabs'
 import { Books } from './Books'
 import { BookRows } from './BookRows'
 import { BookDetailSidebar } from './BookDetailSidebar'
@@ -16,7 +15,7 @@ import { YearlyTopBooks } from './YearlyTopBooks'
 import { TitleWithLine } from '@/components/label/TitleWithLine'
 import { CoutUpText } from '@/components/label/CountUpText'
 import { NO_IMAGE } from '@/libs/constants'
-import { Menu } from './Menu'
+import { SheetTabsWithMenu } from './SheetTabsWithMenu'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import { FaListUl } from 'react-icons/fa'
@@ -89,10 +88,11 @@ export const SheetPage: React.FC<Props> = ({
     return (
       <Container>
         <NextSeo title={`${username}/${year} | kidoku`} />
-        <div className="mb-8 flex items-center border-b border-gray-200">
-          <Tabs sheets={sheets} value={year} username={username} />
-          <Menu currentSheet={year} username={username} />
-        </div>
+        <SheetTabsWithMenu
+          sheets={sheets}
+          currentSheet={year}
+          username={username}
+        />
         <div className="p-10 text-center">
           <div className="mb-4 text-2xl font-bold">
             <span className="text-4xl">🐘 </span>あなたの本がここに表示されます
@@ -106,10 +106,11 @@ export const SheetPage: React.FC<Props> = ({
   return (
     <Container className="mb-12">
       <NextSeo title={`${username}/${year} | kidoku`} />
-      <div className="sticky top-[64px] z-30 -mx-4 flex items-center bg-white px-4 sm:-mx-6 sm:px-6">
-        <Tabs sheets={sheets} value={year} username={username} />
-        <Menu currentSheet={year} username={username} />
-      </div>
+      <SheetTabsWithMenu
+        sheets={sheets}
+        currentSheet={year}
+        username={username}
+      />
 
       <div className="mt-32 text-center">
         <TitleWithLine text="累計読書数" />

--- a/apps/web/src/features/sheet/components/SheetTabsWithMenu.tsx
+++ b/apps/web/src/features/sheet/components/SheetTabsWithMenu.tsx
@@ -6,6 +6,7 @@ interface Props {
   currentSheet: string
   username: string
   menuActivate?: { edit: boolean; delete: boolean }
+  variant?: 'sticky' | 'simple'
 }
 
 export const SheetTabsWithMenu: React.FC<Props> = ({
@@ -13,9 +14,15 @@ export const SheetTabsWithMenu: React.FC<Props> = ({
   currentSheet,
   username,
   menuActivate,
+  variant = 'sticky',
 }) => {
+  const containerClass =
+    variant === 'simple'
+      ? 'mb-8 flex items-center border-b border-gray-200'
+      : 'sticky top-[64px] z-30 -mx-4 flex items-center bg-white px-4 sm:-mx-6 sm:px-6'
+
   return (
-    <div className="sticky top-[64px] z-30 -mx-4 flex items-center bg-white px-4 sm:-mx-6 sm:px-6">
+    <div className={containerClass}>
       <Tabs sheets={sheets} value={currentSheet} username={username} />
       <Menu
         currentSheet={currentSheet}

--- a/apps/web/src/features/sheet/components/SheetTabsWithMenu.tsx
+++ b/apps/web/src/features/sheet/components/SheetTabsWithMenu.tsx
@@ -1,0 +1,27 @@
+import { Tabs } from './Tabs'
+import { Menu } from './Menu'
+
+interface Props {
+  sheets: Array<{ id: string; name: string; order: number }>
+  currentSheet: string
+  username: string
+  menuActivate?: { edit: boolean; delete: boolean }
+}
+
+export const SheetTabsWithMenu: React.FC<Props> = ({
+  sheets,
+  currentSheet,
+  username,
+  menuActivate,
+}) => {
+  return (
+    <div className="sticky top-[64px] z-30 -mx-4 flex items-center bg-white px-4 sm:-mx-6 sm:px-6">
+      <Tabs sheets={sheets} value={currentSheet} username={username} />
+      <Menu
+        currentSheet={currentSheet}
+        username={username}
+        activate={menuActivate}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/features/sheet/components/SheetTotal/SheetTotalPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetTotal/SheetTotalPage.tsx
@@ -1,4 +1,3 @@
-import { Tabs } from '../Tabs'
 import { Category, Year } from '../../types'
 import { TitleWithLine } from '@/components/label/TitleWithLine'
 import { Rankings } from './Rankings'
@@ -7,7 +6,7 @@ import { YearsGraph } from './YearsGraph'
 import { YearlyTopBook } from '@/types/book'
 import { Container } from '@/components/layout/Container'
 import { CoutUpText } from '@/components/label/CountUpText'
-import { Menu } from '../Menu'
+import { SheetTabsWithMenu } from '../SheetTabsWithMenu'
 import { NextSeo } from 'next-seo'
 
 interface Props {
@@ -31,14 +30,12 @@ export const SheetTotalPage: React.FC<Props> = ({
   return (
     <Container>
       <NextSeo title={`${username}/Total | kidoku`} />
-      <div className="sticky top-[64px] z-30 -mx-4 flex items-center bg-white px-4 sm:-mx-6 sm:px-6">
-        <Tabs sheets={sheets} value="total" username={username} />
-        <Menu
-          currentSheet="total"
-          username={username}
-          activate={{ edit: false, delete: false }}
-        />
-      </div>
+      <SheetTabsWithMenu
+        sheets={sheets}
+        currentSheet="total"
+        username={username}
+        menuActivate={{ edit: false, delete: false }}
+      />
       <div className="mb-10 mt-32 text-center">
         <TitleWithLine text="累計読書数" />
         <CoutUpText value={total} unit="冊" />


### PR DESCRIPTION
## Summary
- SheetTabsWithMenuコンポーネントを新規作成し、TabsとMenuコンポーネントの重複コードを解消
- SheetPageとTotalPageで共通のタブ・メニュー表示ロジックを統一
- メニューの有効/無効設定をpropsで制御可能にして柔軟性を向上

## Test plan
- [x] ビルドが正常に完了することを確認
- [x] 型エラーが解消されていることを確認
- [x] 既存の機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)