### PR TITLE
サイドバーのアカウント名をクリックして設定ページに遷移する機能を実装

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -233,7 +233,11 @@ export const Sidebar: React.FC = () => {
             aria-label="ユーザーアカウント"
           >
             <div className="w-full space-y-2">
-              <div className="flex items-center rounded-lg p-2 transition-colors duration-150 hover:bg-white/30">
+              <Link
+                href="/settings/profile"
+                className="flex items-center rounded-lg p-2 transition-colors duration-150 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-main"
+                aria-label="アカウント設定に移動"
+              >
                 <div className="mr-3">
                   <img
                     className="h-9 w-9 rounded-full ring-2 ring-white"
@@ -249,7 +253,7 @@ export const Sidebar: React.FC = () => {
                     {session.user.email}
                   </p>
                 </div>
-              </div>
+              </Link>
               <button
                 onClick={() => signOut()}
                 className="flex w-full items-center rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-all duration-200 hover:bg-white/50 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-main"
@@ -353,7 +357,12 @@ export const Sidebar: React.FC = () => {
                   aria-label="ユーザーアカウント"
                 >
                   <div className="w-full space-y-3">
-                    <div className="flex items-center rounded-lg p-2 transition-colors duration-150 hover:bg-white/30">
+                    <Link
+                      href="/settings/profile"
+                      onClick={closeSidebar}
+                      className="flex items-center rounded-lg p-2 transition-colors duration-150 hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-main"
+                      aria-label="アカウント設定に移動"
+                    >
                       <div className="mr-3">
                         <img
                           className="h-10 w-10 rounded-full ring-2 ring-white"
@@ -369,7 +378,7 @@ export const Sidebar: React.FC = () => {
                           {session.user.email}
                         </p>
                       </div>
-                    </div>
+                    </Link>
                     <button
                       onClick={() => {
                         signOut()


### PR DESCRIPTION
## 概要
サイドバーのアカウント名をクリックすると設定ページ（/settings/profile）に遷移する機能を実装しました。

## 変更内容
- サイドバー（デスクトップ版・モバイル版）のアカウント名表示部分を`<div>`から`<Link>`コンポーネントに変更
- `/settings/profile`ページへのナビゲーション機能を追加
- アクセシビリティ対応：
  - 適切な`aria-label`を設定
  - フォーカス管理（`focus:outline-none focus:ring-2`等）
- モバイル版では、クリック時にサイドバーを自動で閉じる機能を追加

## テスト内容
- ✅ Lint/TypeScriptチェック：問題なし
- ✅ Webアプリテスト：正常に通過
- ✅ ビルド：正常に完了

## 関連Issue
Fixes #31

🤖 Generated with [Claude Code](https://claude.ai/code)