### PR TITLE
fix: タブドラッグ制限とモバイルスクロール改善 (#45)

### DIFF
--- a/apps/web/src/features/sheet/components/Tabs.tsx
+++ b/apps/web/src/features/sheet/components/Tabs.tsx
@@ -93,7 +93,7 @@ export const Tabs: React.FC<Props> = ({ value, sheets, username }) => {
   }
 
   return (
-    <div className="no-scrollbar mobile-tab-scroll flex touch-pan-x items-center justify-start overflow-x-auto">
+    <div className="no-scrollbar mobile-tab-scroll flex items-center justify-start overflow-x-auto">
       <div className="flex items-center">
         {/* TOTAL tab - fixed position */}
         <button
@@ -150,10 +150,7 @@ export const Tabs: React.FC<Props> = ({ value, sheets, username }) => {
                 stiffness: 600,
                 damping: 30,
               }}
-              drag={isMine}
-              dragConstraints={{ left: 0, right: 0 }}
-              dragElastic={0.1}
-              dragMomentum={false}
+              drag={isMine ? 'x' : false}
             >
               <button
                 className={twMerge(

--- a/apps/web/src/pages/global.css
+++ b/apps/web/src/pages/global.css
@@ -30,18 +30,6 @@ div {
   /* モバイルタブスクロール改善 */
   .mobile-tab-scroll {
     -webkit-overflow-scrolling: touch;
-    scroll-behavior: smooth;
-    overscroll-behavior-x: contain;
-  }
-
-  @media (max-width: 768px) {
-    .mobile-tab-scroll {
-      scroll-snap-type: x proximity;
-    }
-    
-    .mobile-tab-scroll > * {
-      scroll-snap-align: start;
-    }
   }
 
   .readmore-blur::before {

--- a/apps/web/src/pages/global.css
+++ b/apps/web/src/pages/global.css
@@ -27,6 +27,23 @@ div {
     display: none;
   }
 
+  /* モバイルタブスクロール改善 */
+  .mobile-tab-scroll {
+    -webkit-overflow-scrolling: touch;
+    scroll-behavior: smooth;
+    overscroll-behavior-x: contain;
+  }
+
+  @media (max-width: 768px) {
+    .mobile-tab-scroll {
+      scroll-snap-type: x proximity;
+    }
+    
+    .mobile-tab-scroll > * {
+      scroll-snap-align: start;
+    }
+  }
+
   .readmore-blur::before {
     content: '';
     width: 100%;


### PR DESCRIPTION
## 概要
Issue #45 の対応として、タブのドラッグ制限機能とモバイルでのスクロール感度改善を実装しました。

## 変更内容

### 1. ユーザー権限によるタブドラッグ制限
- `useSession`でユーザー認証状態を取得
- タブの所有者のみがドラッグ&ドロップによる並び替えを実行可能
- 他のユーザーは表示のみで、タブの移動は制限

### 2. モバイルでのタブスクロール感度改善
- `touch-pan-x`クラスを追加してタッチ操作を最適化
- カスタムCSS `mobile-tab-scroll`を実装：
  - `-webkit-overflow-scrolling: touch`でスムーズスクロール
  - `overscroll-behavior-x: contain`で横スクロール制御
  - モバイル向けスクロールスナップ機能
- Framer Motionのドラッグ設定を調整

## 修正ファイル
- `src/features/sheet/components/Tabs.tsx`
- `src/pages/global.css`

## テスト計画
- [ ] ログインユーザーが自分のタブを並び替えできることを確認
- [ ] 他のユーザーのタブが並び替えできないことを確認
- [ ] モバイルでタブの横スクロールがスムーズに動作することを確認
- [ ] タブクリックによるページ遷移が正常に動作することを確認

Closes #45