### PR TITLE
fix: isMine判定をusernameからuserIdベースに変更

### DIFF
--- a/apps/web/src/features/sheet/components/Menu.tsx
+++ b/apps/web/src/features/sheet/components/Menu.tsx
@@ -14,6 +14,7 @@ import { BsThreeDots } from 'react-icons/bs'
 interface Props {
   currentSheet: string
   username: string
+  userId: string
   activate?: {
     edit: boolean
     delete: boolean
@@ -22,6 +23,7 @@ interface Props {
 export const Menu: React.FC<Props> = ({
   currentSheet,
   username,
+  userId,
   activate = { edit: true, delete: true },
 }) => {
   const dropdownRef = useRef(null)
@@ -30,7 +32,7 @@ export const Menu: React.FC<Props> = ({
   const [openAdd, setOpenAdd] = useState(false)
   const [openEdit, setOpenEdit] = useState(false)
   const [openDelete, setOpenDelete] = useState(false)
-  const isMine = session && session.user.name === username
+  const isMine = session && session.user.id === userId
   const variants: Variants = {
     open: {
       opacity: 1,

--- a/apps/web/src/features/sheet/components/SheetPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetPage.tsx
@@ -35,6 +35,7 @@ interface Props {
   year: string
   sheets: Array<{ id: string; name: string; order: number }>
   username: string
+  userId: string
   yearlyTopBooks: YearlyTopBook[]
   aiSummaries: AiSummariesJson[]
 }
@@ -44,6 +45,7 @@ export const SheetPage: React.FC<Props> = ({
   year,
   sheets,
   username,
+  userId,
   yearlyTopBooks,
   aiSummaries,
 }) => {
@@ -66,8 +68,7 @@ export const SheetPage: React.FC<Props> = ({
   const [openFullPageModal, setOpenFullPageModal] = useState(false)
   const [fullPageBook, setFullPageBook] = useState<Book>(null)
 
-  const isMine =
-    data.length > 0 && session && session.user.id === data[0].userId
+  const isMine = session && session.user.id === userId
   useEffect(() => {
     if (isMine) {
       setCurrentData(res?.books || [])
@@ -92,6 +93,7 @@ export const SheetPage: React.FC<Props> = ({
           sheets={sheets}
           currentSheet={year}
           username={username}
+          userId={userId}
           variant="simple"
         />
         <div className="p-10 text-center">
@@ -111,6 +113,7 @@ export const SheetPage: React.FC<Props> = ({
         sheets={sheets}
         currentSheet={year}
         username={username}
+        userId={userId}
       />
 
       <div className="mt-32 text-center">

--- a/apps/web/src/features/sheet/components/SheetTabsWithMenu.tsx
+++ b/apps/web/src/features/sheet/components/SheetTabsWithMenu.tsx
@@ -5,6 +5,7 @@ interface Props {
   sheets: Array<{ id: string; name: string; order: number }>
   currentSheet: string
   username: string
+  userId: string
   menuActivate?: { edit: boolean; delete: boolean }
   variant?: 'sticky' | 'simple'
 }
@@ -13,6 +14,7 @@ export const SheetTabsWithMenu: React.FC<Props> = ({
   sheets,
   currentSheet,
   username,
+  userId,
   menuActivate,
   variant = 'sticky',
 }) => {
@@ -23,10 +25,11 @@ export const SheetTabsWithMenu: React.FC<Props> = ({
 
   return (
     <div className={containerClass}>
-      <Tabs sheets={sheets} value={currentSheet} username={username} />
+      <Tabs sheets={sheets} value={currentSheet} username={username} userId={userId} />
       <Menu
         currentSheet={currentSheet}
         username={username}
+        userId={userId}
         activate={menuActivate}
       />
     </div>

--- a/apps/web/src/features/sheet/components/SheetTabsWithMenu.tsx
+++ b/apps/web/src/features/sheet/components/SheetTabsWithMenu.tsx
@@ -25,7 +25,12 @@ export const SheetTabsWithMenu: React.FC<Props> = ({
 
   return (
     <div className={containerClass}>
-      <Tabs sheets={sheets} value={currentSheet} username={username} userId={userId} />
+      <Tabs
+        sheets={sheets}
+        value={currentSheet}
+        username={username}
+        userId={userId}
+      />
       <Menu
         currentSheet={currentSheet}
         username={username}

--- a/apps/web/src/features/sheet/components/SheetTotal/SheetTotalPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetTotal/SheetTotalPage.tsx
@@ -15,6 +15,7 @@ interface Props {
   years: Year[]
   sheets: Array<{ id: string; name: string; order: number }>
   username: string
+  userId: string
   yearlyTopBooks: YearlyTopBook[]
 }
 export const SheetTotalPage: React.FC<Props> = ({
@@ -23,6 +24,7 @@ export const SheetTotalPage: React.FC<Props> = ({
   years,
   sheets,
   username,
+  userId,
   yearlyTopBooks,
 }) => {
   const average = years.length === 0 ? 0 : Math.ceil(total / years.length)
@@ -34,6 +36,7 @@ export const SheetTotalPage: React.FC<Props> = ({
         sheets={sheets}
         currentSheet="total"
         username={username}
+        userId={userId}
         menuActivate={{ edit: false, delete: false }}
       />
       <div className="mb-10 mt-32 text-center">

--- a/apps/web/src/features/sheet/components/Tabs.tsx
+++ b/apps/web/src/features/sheet/components/Tabs.tsx
@@ -14,8 +14,9 @@ interface Props {
   sheets: Array<{ id: string; name: string; order: number }>
   value: string
   username: string
+  userId: string
 }
-export const Tabs: React.FC<Props> = ({ value, sheets, username }) => {
+export const Tabs: React.FC<Props> = ({ value, sheets, username, userId }) => {
   const router = useRouter()
   const { data: session } = useSession()
   const [tab, setTab] = useState(value)
@@ -27,7 +28,7 @@ export const Tabs: React.FC<Props> = ({ value, sheets, username }) => {
   const [longPressTimer, setLongPressTimer] = useState<NodeJS.Timeout | null>(
     null
   )
-  const isMine = session && session.user.name === username
+  const isMine = session && session.user.id === userId
 
   const { data } = useSWR<UserImageResponse>(
     `/api/user/image?username=${username}`,

--- a/apps/web/src/pages/[user]/sheets/[year].tsx
+++ b/apps/web/src/pages/[user]/sheets/[year].tsx
@@ -80,6 +80,7 @@ export async function getStaticProps(context) {
         order: sheet.order || 0,
       })),
       username,
+      userId,
       yearlyTopBooks,
       aiSummaries: aiSummaries.map((v) => v.analysis),
     },

--- a/apps/web/src/pages/[user]/sheets/total.tsx
+++ b/apps/web/src/pages/[user]/sheets/total.tsx
@@ -79,6 +79,7 @@ export const getStaticProps = async (ctx) => {
               order: sheet.order || 0,
             })),
       username,
+      userId,
       yearlyTopBooks,
     },
     revalidate: 5,


### PR DESCRIPTION
## 概要
Issue #48 の対応として、`isMine` の判定方法を `username` から `userId` に変更しました。

## 変更内容

### 1. pages からの userId 渡し
- `pages/[user]/sheets/[year].tsx`: getStaticProps で取得済みの userId を props に追加
- `pages/[user]/sheets/total.tsx`: getStaticProps で取得済みの userId を props に追加

### 2. コンポーネントチェーンでの userId 伝達
以下の順序で userId を props として追加：
- `SheetPage` / `SheetTotalPage`
- `SheetTabsWithMenu`
- `Tabs` / `Menu`

### 3. 判定ロジックの変更
- `Tabs.tsx`: `session.user.name === username` → `session.user.id === userId`
- `Menu.tsx`: `session.user.name === username` → `session.user.id === userId`
- `SheetPage.tsx`: `data[0].userId` → props の `userId` を直接使用

## 影響範囲
- username は引き続き表示用（ユーザー画像取得、URL生成など）として使用
- userId は所有者判定専用として使用
- 他のコンポーネント（BookRows、YearlyTopBooks など）はすでに userId ベースの判定を使用しているため変更なし

## テスト
- 開発サーバーで正常起動を確認
- 型チェックでエラーなし（既存の TreemapGraph の型エラーは今回の変更とは無関係）

Closes #48