### PR TITLE
feat: 本追加後の自動編集モード遷移機能を実装 (#11)

### DIFF
--- a/apps/web/src/components/input/SearchBox/AddModal.tsx
+++ b/apps/web/src/components/input/SearchBox/AddModal.tsx
@@ -319,17 +319,30 @@ export const AddModal: React.FC = () => {
                   </div>
                 )}
                 {response?.bookId > 0 ? (
-                  <button
-                    className="flex h-12 w-full items-center justify-center rounded-b-md bg-green-600 px-4 py-1 font-bold text-white hover:bg-green-700 disabled:bg-blue-700"
-                    onClick={() => {
-                      setOpen(false)
-                      router.push(
-                        `/${session.user.name}/sheets/${response.sheetName}?book=${response.bookId}`
-                      )
-                    }}
-                  >
-                    <span id="rewardId">シートに飛ぶ</span>
-                  </button>
+                  <div className="flex">
+                    <button
+                      className="flex h-12 w-1/2 items-center justify-center rounded-bl-md bg-green-600 px-4 py-1 font-bold text-white hover:bg-green-700"
+                      onClick={() => {
+                        setOpen(false)
+                        router.push(
+                          `/${session.user.name}/sheets/${response.sheetName}?book=${response.bookId}&edit=true`
+                        )
+                      }}
+                    >
+                      <span>編集する</span>
+                    </button>
+                    <button
+                      className="flex h-12 w-1/2 items-center justify-center rounded-br-md border-l border-green-500 bg-green-600 px-4 py-1 font-bold text-white hover:bg-green-700"
+                      onClick={() => {
+                        setOpen(false)
+                        router.push(
+                          `/${session.user.name}/sheets/${response.sheetName}?book=${response.bookId}`
+                        )
+                      }}
+                    >
+                      <span id="rewardId">シートに飛ぶ</span>
+                    </button>
+                  </div>
                 ) : (
                   <button
                     className="flex h-12 w-full items-center justify-center rounded-b-md bg-blue-600 px-4 py-1 font-bold text-white hover:bg-blue-700 disabled:bg-gray-500"

--- a/apps/web/src/features/sheet/components/BookDetailSidebar.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailSidebar.tsx
@@ -13,6 +13,7 @@ interface Props {
   open: boolean
   onClose: () => void
   onExpandToFullPage: () => void
+  initialEditMode?: boolean
 }
 
 export const BookDetailSidebar: React.FC<Props> = ({
@@ -20,6 +21,7 @@ export const BookDetailSidebar: React.FC<Props> = ({
   open,
   onClose,
   onExpandToFullPage,
+  initialEditMode = false,
 }) => {
   const router = useRouter()
   const { mutate } = useSWRConfig()
@@ -35,7 +37,19 @@ export const BookDetailSidebar: React.FC<Props> = ({
   useEffect(() => {
     setNewBook(book)
     setCurrentBook(book)
-  }, [book])
+    if (initialEditMode && book) {
+      // 編集モードで開く場合、非マスクのデータを取得
+      fetch(`/api/book/${book?.id}`)
+        .then((res) => res.json())
+        .then((res) => {
+          if (res.result) {
+            setCurrentBook(res.book)
+            setNewBook(res.book)
+            setEdit(true)
+          }
+        })
+    }
+  }, [book, initialEditMode])
 
   const onClickEdit = async () => {
     const isDiff = Object.keys(book).some((key) => book[key] !== newBook[key])

--- a/apps/web/src/features/sheet/components/Books.tsx
+++ b/apps/web/src/features/sheet/components/Books.tsx
@@ -112,6 +112,7 @@ export const Books: React.FC<Props> = ({ bookId, books, year }) => {
             setOpenSidebar(false)
           }
         }}
+        initialEditMode={router.query.edit === 'true'}
       />
     </>
   )


### PR DESCRIPTION
## Summary
- 本を追加した後、自動的に編集モードに遷移する機能を実装しました
- 追加後は「編集する」と「シートに飛ぶ」の2つの選択肢を提供
- 編集をスキップして直接シートに移動することも可能です

## Changes
- `AddModal.tsx`: 本追加成功後のボタンを2つに分割
  - 「編集する」ボタン：クエリパラメータ`edit=true`を付与してシートページへ遷移
  - 「シートに飛ぶ」ボタン：従来通りシートページへ遷移
- `BookDetailSidebar.tsx`: `initialEditMode`プロパティを追加し、初期状態で編集モードで開く機能を実装
- `Books.tsx`: URLクエリパラメータ`edit=true`を検出し、BookDetailSidebarに渡すように修正

## Test plan
- [ ] 本を追加して「編集する」ボタンをクリックすると、編集モードでサイドバーが開く
- [ ] 本を追加して「シートに飛ぶ」ボタンをクリックすると、通常の詳細表示モードでサイドバーが開く
- [ ] 編集モードで開いた場合、変更をキャンセルできることを確認
- [ ] 編集モードで開いた場合、変更を保存できることを確認
- [ ] URLに直接`?book=XXX&edit=true`を入力しても編集モードで開くことを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)