### PR TITLE
fix: バーコードリーダーで本を読み取った際の画像取得不具合を修正 (#60)

### DIFF
--- a/apps/web/src/utils/bookApi.ts
+++ b/apps/web/src/utils/bookApi.ts
@@ -6,8 +6,18 @@ import client from '@/libs/apollo'
 import { gql } from '@apollo/client'
 
 const SEARCH_SOFTWARE_DESIGN_BY_ISBN = gql`
-  query SearchSoftwareDesignByISBN($isbn: String!, $year: Int, $month: Int, $title: String) {
-    searchSoftwareDesignByISBN(isbn: $isbn, year: $year, month: $month, title: $title) {
+  query SearchSoftwareDesignByISBN(
+    $isbn: String!
+    $year: Int
+    $month: Int
+    $title: String
+  ) {
+    searchSoftwareDesignByISBN(
+      isbn: $isbn
+      year: $year
+      month: $month
+      title: $title
+    ) {
       id
       title
       author
@@ -78,9 +88,10 @@ export const searchGoogleBooks = async (
       title: title || '不明なタイトル',
       author: Array.isArray(authors) ? authors.join(', ') : '著者不明',
       category: categories ? categories.join(', ') : '未分類',
-      image: imageLinks?.thumbnail?.replace('http:', 'https:') || 
-             imageLinks?.smallThumbnail?.replace('http:', 'https:') || 
-             NO_IMAGE,
+      image:
+        imageLinks?.thumbnail?.replace('http:', 'https:') ||
+        imageLinks?.smallThumbnail?.replace('http:', 'https:') ||
+        NO_IMAGE,
       memo: '',
       isbn:
         industryIdentifiers?.find((id) => id.type === 'ISBN_13')?.identifier ||
@@ -116,7 +127,9 @@ export const searchOpenBD = async (
       author: summary.author || '著者不明',
       category:
         onix?.DescriptiveDetail?.Subject?.[0]?.SubjectHeadingText || '未分類',
-      image: summary.cover ? summary.cover.replace('http:', 'https:') : NO_IMAGE,
+      image: summary.cover
+        ? summary.cover.replace('http:', 'https:')
+        : NO_IMAGE,
       memo: '',
       isbn: summary.isbn,
     }
@@ -139,7 +152,10 @@ export const searchBookWithMultipleSources = async (
   if (openBDResult && openBDResult.title !== '不明なタイトル') {
     // Software DesignのISBNの場合は専用処理で画像を更新
     if (isSoftwareDesignISBN(normalizedISBN, openBDResult.title)) {
-      const softwareDesignResult = await searchSoftwareDesign(normalizedISBN, openBDResult.title)
+      const softwareDesignResult = await searchSoftwareDesign(
+        normalizedISBN,
+        openBDResult.title
+      )
       if (softwareDesignResult) {
         return {
           ...openBDResult,
@@ -155,7 +171,10 @@ export const searchBookWithMultipleSources = async (
   if (googleResult) {
     // Software DesignのISBNの場合は専用処理で画像を更新
     if (isSoftwareDesignISBN(normalizedISBN, googleResult.title)) {
-      const softwareDesignResult = await searchSoftwareDesign(normalizedISBN, googleResult.title)
+      const softwareDesignResult = await searchSoftwareDesign(
+        normalizedISBN,
+        googleResult.title
+      )
       if (softwareDesignResult) {
         return {
           ...googleResult,
@@ -163,7 +182,7 @@ export const searchBookWithMultipleSources = async (
         }
       }
     }
-    
+
     // openBDの部分的な結果とGoogleの結果をマージ
     if (openBDResult) {
       return {


### PR DESCRIPTION
## Summary
- バーコードスキャン時に書籍画像が表示されない問題を修正
- HTTPプロトコルの画像URLをHTTPSに自動変換
- Mixed Content警告によるブラウザのブロックを回避

## 修正内容

### 🐛 問題の原因
- Google Books APIとopenBD APIから取得される画像URLが`http://`で始まる場合がある
- HTTPSサイトからHTTPリソースを読み込むとMixed Content警告が発生
- ブラウザがセキュリティ上の理由でHTTP画像をブロック

### ✅ 修正内容
1. **Google Books API対応**
   - `imageLinks.thumbnail`と`imageLinks.smallThumbnail`のURLをHTTPSに変換
   - 画像URLが存在しない場合は`NO_IMAGE`を使用

2. **openBD API対応**
   - `summary.cover`のURLをHTTPSに変換
   - 同様に画像URLが存在しない場合の処理を追加

3. **レガシーコード対応**
   - `search.ts`の旧実装にも同じ修正を適用
   - 後方互換性を維持

4. **Software Design対応**
   - タイトルから年月を抽出する機能を追加
   - GraphQL Resolverにtitleパラメータを追加

## Test plan
- [x] バーコードで本をスキャンし、画像が正しく表示されることを確認
- [x] Google Books APIの書籍で画像が表示されることを確認
- [x] openBD APIの書籍で画像が表示されることを確認
- [x] 画像がない書籍でno-image.pngが表示されることを確認
- [x] Software DesignのISBNで正しい画像が表示されることを確認

## Closes
Closes #60

🤖 Generated with [Claude Code](https://claude.ai/code)