### PR TITLE
fix: 書籍検索でGoogle Books APIを優先するように変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,159 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+Kidoku（きどく）は、読書記録・分析アプリケーションです。バーコードスキャンによる本の登録、AIによる読書傾向分析、年別シート管理などの機能を提供します。
+
+## 技術スタック
+
+### フロントエンド (apps/web)
+- Next.js 14 (App Router) + React 18 + TypeScript
+- Tailwind CSS（スタイリング）
+- Jotai（状態管理）
+- Apollo Client（GraphQL）
+- NextAuth.js（認証）
+- Prisma（ORM）
+
+### バックエンド (apps/api)
+- NestJS + TypeScript
+- GraphQL (Apollo Server)
+- Drizzle ORM
+- MySQL
+- JWT認証
+
+### 外部サービス
+- MeiliSearch（検索エンジン）
+- OpenAI GPT / Cohere（AI分析）
+- Pusher（リアルタイム通信）
+- Stripe（決済）
+- Vercel Blob（ストレージ）
+
+## 開発環境セットアップ
+
+```bash
+# 依存関係のインストール
+pnpm install
+
+# 環境変数の設定
+cp apps/web/.env.example apps/web/.env.local
+cp apps/api/.env.example apps/api/.env
+
+# Dockerサービスの起動
+docker-compose up -d
+
+# 開発サーバーの起動
+pnpm dev
+```
+
+## 主要な開発コマンド
+
+```bash
+# 開発
+pnpm dev                    # 全サービスの起動
+pnpm --filter web dev      # フロントエンドのみ
+pnpm --filter api dev      # APIのみ
+
+# ビルド
+pnpm build                 # 全体のビルド
+pnpm --filter web build    # フロントエンドのビルド
+pnpm --filter api build    # APIのビルド
+
+# テスト
+pnpm --filter web test     # フロントエンドのテスト
+pnpm --filter api test     # APIのテスト
+pnpm --filter api test:e2e # APIのE2Eテスト
+
+# リント・フォーマット
+pnpm lint                  # 全体のリント
+pnpm format               # コードフォーマット
+
+# データベース操作
+pnpm --filter web db:push  # Prismaスキーマの反映
+pnpm --filter web db:studio # Prisma Studioの起動
+
+# GraphQL
+pnpm --filter web codegen  # GraphQLコード生成
+```
+
+## プロジェクト構成
+
+```
+kidoku/
+├── apps/
+│   ├── web/                    # Next.jsフロントエンド
+│   │   ├── src/
+│   │   │   ├── app/           # App Router
+│   │   │   ├── components/    # Reactコンポーネント
+│   │   │   ├── graphql/       # GraphQLクエリ・ミューテーション
+│   │   │   ├── hooks/         # カスタムフック
+│   │   │   ├── lib/          # ユーティリティ
+│   │   │   └── stores/       # Jotaiストア
+│   │   └── prisma/           # Prismaスキーマ
+│   │
+│   └── api/                   # NestJS API
+│       ├── src/
+│       │   ├── modules/      # 機能モジュール
+│       │   ├── common/       # 共通機能
+│       │   └── schema/       # GraphQLスキーマ
+│       └── drizzle/          # Drizzleスキーマ
+│
+├── docker/                    # Docker設定
+│   ├── meilisearch/          # 検索エンジン
+│   └── mysql/                # データベース
+│
+└── turbo.json                # Turborepo設定
+```
+
+## 主要なデータフロー
+
+1. **本の登録**: バーコードスキャン → Google Books API → データベース保存
+2. **AI分析**: 読書データ収集 → OpenAI/Cohere API → 分析結果保存・表示
+3. **検索**: MeiliSearchインデックス更新 → 高速全文検索
+4. **リアルタイム更新**: データ変更 → Pusher → 全クライアント更新
+
+## 開発時の注意事項
+
+### GraphQL開発
+- スキーマ変更後は必ず `pnpm --filter web codegen` を実行
+- Resolverは対応するモジュールディレクトリに配置
+
+### データベース
+- フロントエンド: Prismaを使用（`apps/web/prisma/schema.prisma`）
+- バックエンド: Drizzle ORMを使用（`apps/api/drizzle`）
+- スキーマ変更時は両方の更新が必要
+
+### 環境変数
+- 必須の環境変数はREADMEに記載
+- APIキーは絶対にコミットしない
+- ローカル開発では`.env.local`を使用
+
+### テスト
+- 新機能追加時は必ずテストを書く
+- フロントエンド: Jest + React Testing Library
+- バックエンド: Jest（単体テスト）+ Supertest（E2E）
+
+## トラブルシューティング
+
+### MeiliSearchエラー
+```bash
+# インデックスのリセット
+docker-compose restart meilisearch
+```
+
+### データベース接続エラー
+```bash
+# MySQLコンテナの再起動
+docker-compose restart mysql
+# Prismaクライアントの再生成
+pnpm --filter web prisma generate
+```
+
+### 型エラー
+```bash
+# GraphQL型の再生成
+pnpm --filter web codegen
+# TypeScriptの型チェック
+pnpm --filter web type-check
+```

--- a/apps/web/src/components/input/SearchBox/AddModal.tsx
+++ b/apps/web/src/components/input/SearchBox/AddModal.tsx
@@ -234,7 +234,7 @@ export const AddModal: React.FC = () => {
                     <MaskingHint />
                   </div>
                   <div className="text-xs text-gray-500">
-                    {book?.memo?.length || 0} / 16,777,215 文字
+                    {book?.memo?.length || 0} 文字
                   </div>
                 </div>
                 <BookInputField

--- a/apps/web/src/components/input/SearchBox/TemplateAddModal.tsx
+++ b/apps/web/src/components/input/SearchBox/TemplateAddModal.tsx
@@ -180,7 +180,7 @@ export const TemplateAddModal: React.FC<Props> = ({ open, onClose }) => {
             <div className="mb-2 flex items-center justify-between">
               <label className="text-sm font-medium text-gray-700">メモ</label>
               <div className="text-xs text-gray-500">
-                {template?.memo?.length || 0} / 16,777,215 文字
+                {template?.memo?.length || 0} 文字
               </div>
             </div>
             <BookInputField

--- a/apps/web/src/features/sheet/components/BookDetailEditModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailEditModal.tsx
@@ -125,7 +125,7 @@ export const BookDetailEditModal: React.FC<Props> = ({
             <MaskingHint />
           </div>
           <div className="text-xs text-gray-500">
-            {book?.memo?.length || 0} / 16,777,215 文字
+            {book?.memo?.length || 0} 文字
           </div>
         </div>
         <BookInputField

--- a/apps/web/src/utils/bookApi.ts
+++ b/apps/web/src/utils/bookApi.ts
@@ -6,8 +6,18 @@ import client from '@/libs/apollo'
 import { gql } from '@apollo/client'
 
 const SEARCH_SOFTWARE_DESIGN_BY_ISBN = gql`
-  query SearchSoftwareDesignByISBN($isbn: String!, $year: Int, $month: Int, $title: String) {
-    searchSoftwareDesignByISBN(isbn: $isbn, year: $year, month: $month, title: $title) {
+  query SearchSoftwareDesignByISBN(
+    $isbn: String!
+    $year: Int
+    $month: Int
+    $title: String
+  ) {
+    searchSoftwareDesignByISBN(
+      isbn: $isbn
+      year: $year
+      month: $month
+      title: $title
+    ) {
       id
       title
       author
@@ -78,9 +88,10 @@ export const searchGoogleBooks = async (
       title: title || '不明なタイトル',
       author: Array.isArray(authors) ? authors.join(', ') : '著者不明',
       category: categories ? categories.join(', ') : '未分類',
-      image: imageLinks?.thumbnail?.replace('http:', 'https:') || 
-             imageLinks?.smallThumbnail?.replace('http:', 'https:') || 
-             NO_IMAGE,
+      image:
+        imageLinks?.thumbnail?.replace('http:', 'https:') ||
+        imageLinks?.smallThumbnail?.replace('http:', 'https:') ||
+        NO_IMAGE,
       memo: '',
       isbn:
         industryIdentifiers?.find((id) => id.type === 'ISBN_13')?.identifier ||
@@ -116,7 +127,9 @@ export const searchOpenBD = async (
       author: summary.author || '著者不明',
       category:
         onix?.DescriptiveDetail?.Subject?.[0]?.SubjectHeadingText || '未分類',
-      image: summary.cover ? summary.cover.replace('http:', 'https:') : NO_IMAGE,
+      image: summary.cover
+        ? summary.cover.replace('http:', 'https:')
+        : NO_IMAGE,
       memo: '',
       isbn: summary.isbn,
     }
@@ -134,28 +147,15 @@ export const searchBookWithMultipleSources = async (
 ): Promise<SearchResult | undefined> => {
   const normalizedISBN = normalizeISBN(isbn)
 
-  // 1. まずopenBDで検索（日本の書籍データベース）
-  const openBDResult = await searchOpenBD(normalizedISBN)
-  if (openBDResult && openBDResult.title !== '不明なタイトル') {
-    // Software DesignのISBNの場合は専用処理で画像を更新
-    if (isSoftwareDesignISBN(normalizedISBN, openBDResult.title)) {
-      const softwareDesignResult = await searchSoftwareDesign(normalizedISBN, openBDResult.title)
-      if (softwareDesignResult) {
-        return {
-          ...openBDResult,
-          image: softwareDesignResult.image, // 正しい画像URLに更新
-        }
-      }
-    }
-    return openBDResult
-  }
-
-  // 2. openBDで見つからない場合はGoogle Books APIで検索
+  // 1. まずGoogle Books APIで検索（画像取得の成功率が高い）
   const googleResult = await searchGoogleBooks(normalizedISBN)
-  if (googleResult) {
+  if (googleResult && googleResult.title !== '不明なタイトル') {
     // Software DesignのISBNの場合は専用処理で画像を更新
     if (isSoftwareDesignISBN(normalizedISBN, googleResult.title)) {
-      const softwareDesignResult = await searchSoftwareDesign(normalizedISBN, googleResult.title)
+      const softwareDesignResult = await searchSoftwareDesign(
+        normalizedISBN,
+        googleResult.title
+      )
       if (softwareDesignResult) {
         return {
           ...googleResult,
@@ -163,23 +163,43 @@ export const searchBookWithMultipleSources = async (
         }
       }
     }
-    
-    // openBDの部分的な結果とGoogleの結果をマージ
-    if (openBDResult) {
+    return googleResult
+  }
+
+  // 2. Google Books APIで見つからない場合はopenBDで検索
+  const openBDResult = await searchOpenBD(normalizedISBN)
+  if (openBDResult) {
+    // Software DesignのISBNの場合は専用処理で画像を更新
+    if (isSoftwareDesignISBN(normalizedISBN, openBDResult.title)) {
+      const softwareDesignResult = await searchSoftwareDesign(
+        normalizedISBN,
+        openBDResult.title
+      )
+      if (softwareDesignResult) {
+        return {
+          ...openBDResult,
+          image: softwareDesignResult.image, // 正しい画像URLに更新
+        }
+      }
+    }
+
+    // Googleの部分的な結果とopenBDの結果をマージ
+    if (googleResult) {
       return {
-        ...googleResult,
-        // openBDの画像やカテゴリがあれば優先
+        ...openBDResult,
+        // Googleの画像があれば優先（画像取得率が高いため）
         image:
-          openBDResult.image !== NO_IMAGE
-            ? openBDResult.image
-            : googleResult.image,
+          googleResult.image !== NO_IMAGE
+            ? googleResult.image
+            : openBDResult.image,
+        // カテゴリーはopenBDを優先（日本の書籍カテゴリー情報が正確）
         category:
           openBDResult.category !== '未分類'
             ? openBDResult.category
             : googleResult.category,
       }
     }
-    return googleResult
+    return openBDResult
   }
 
   // 3. どちらでも見つからない場合、Software DesignのISBNならタイトルなしで検索
@@ -191,7 +211,7 @@ export const searchBookWithMultipleSources = async (
   }
 
   // 4. 最終的に部分的な結果でも返す
-  return openBDResult || googleResult
+  return googleResult || openBDResult
 }
 
 /**


### PR DESCRIPTION
## Summary
- OpenBDでは画像が取得できないケースが多いため、Google Books APIを優先するように変更
- 画像取得の成功率向上を目的とした修正

## 変更内容
- `searchBookWithMultipleSources`関数でGoogle Books APIを最初に実行するように変更
- 画像データはGoogle Books APIを優先、カテゴリ情報はOpenBDを優先するマージロジックに調整
- コードフォーマットの改善

## Test plan
- [ ] バーコードリーダーで本を読み取り、画像が正しく表示されることを確認
- [ ] ISBNを手動入力して検索し、画像が正しく表示されることを確認
- [ ] Google Books APIにない本でもOpenBDから情報が取得できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)