### PR TITLE
feat: Grafana + Prometheusによる監視システムを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /docker/meilisearch/data/meilisearch
 /docker/mysql/data/*
 !/docker/mysql/data/.gitkeep
+/docker/prometheus/data
+/docker/grafana/data
 **/node_modules
 
 # testing

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,15 +32,17 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@willsoto/nestjs-prometheus": "^6.0.2",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "drizzle-orm": "^0.43.1",
     "graphql": "^16.11.0",
     "mysql2": "^3.14.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1",
-    "class-validator": "^0.14.1",
-    "class-transformer": "^0.5.1"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,11 +3,14 @@ import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { join } from 'path';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { HelloModule } from './modules/hello/hello.module';
 import { SheetsModule } from './modules/sheets/sheets.module';
 import { CommentsModule } from './modules/comments/comments.module';
 import { HealthModule } from './health/health.module';
 import { SoftwareDesignModule } from './modules/software-design/software-design.module';
+import { MetricsModule } from './modules/metrics/metrics.module';
+import { MetricsInterceptor } from './common/interceptors/metrics.interceptor';
 
 @Module({
   imports: [
@@ -30,6 +33,13 @@ import { SoftwareDesignModule } from './modules/software-design/software-design.
     CommentsModule,
     HealthModule,
     SoftwareDesignModule,
+    MetricsModule,
+  ],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: MetricsInterceptor,
+    },
   ],
 })
 export class AppModule {}

--- a/apps/api/src/common/interceptors/metrics.interceptor.ts
+++ b/apps/api/src/common/interceptors/metrics.interceptor.ts
@@ -1,0 +1,50 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common'
+import { Observable } from 'rxjs'
+import { tap } from 'rxjs/operators'
+import { Counter, Histogram } from 'prom-client'
+import { InjectMetric } from '@willsoto/nestjs-prometheus'
+
+@Injectable()
+export class MetricsInterceptor implements NestInterceptor {
+  constructor(
+    @InjectMetric('http_requests_total')
+    private readonly httpRequestsTotal: Counter<string>,
+    @InjectMetric('http_request_duration_seconds')
+    private readonly httpRequestDuration: Histogram<string>,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const startTime = Date.now()
+    const request = context.switchToHttp().getRequest()
+    const response = context.switchToHttp().getResponse()
+
+    return next.handle().pipe(
+      tap(() => {
+        const duration = (Date.now() - startTime) / 1000
+        const route = request.route?.path || request.url
+        const method = request.method
+        const statusCode = response.statusCode
+
+        this.httpRequestsTotal.inc({
+          method,
+          route,
+          status_code: statusCode.toString(),
+        })
+
+        this.httpRequestDuration.observe(
+          {
+            method,
+            route,
+            status_code: statusCode.toString(),
+          },
+          duration,
+        )
+      }),
+    )
+  }
+}

--- a/apps/api/src/modules/metrics/metrics.controller.ts
+++ b/apps/api/src/modules/metrics/metrics.controller.ts
@@ -1,12 +1,12 @@
-import { Controller, Get, Res } from '@nestjs/common'
-import { Response } from 'express'
-import { register } from 'prom-client'
+import { Controller, Get, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { register } from 'prom-client';
 
 @Controller()
 export class MetricsController {
   @Get('/metrics')
   async getMetrics(@Res() response: Response) {
-    response.set('Content-Type', register.contentType)
-    response.end(await register.metrics())
+    response.set('Content-Type', register.contentType);
+    response.end(await register.metrics());
   }
 }

--- a/apps/api/src/modules/metrics/metrics.controller.ts
+++ b/apps/api/src/modules/metrics/metrics.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Res } from '@nestjs/common'
+import { Response } from 'express'
+import { register } from 'prom-client'
+
+@Controller()
+export class MetricsController {
+  @Get('/metrics')
+  async getMetrics(@Res() response: Response) {
+    response.set('Content-Type', register.contentType)
+    response.end(await register.metrics())
+  }
+}

--- a/apps/api/src/modules/metrics/metrics.module.ts
+++ b/apps/api/src/modules/metrics/metrics.module.ts
@@ -1,0 +1,40 @@
+import { Module } from '@nestjs/common'
+import { PrometheusModule } from '@willsoto/nestjs-prometheus'
+import { MetricsController } from './metrics.controller'
+import {
+  httpRequestsTotal,
+  httpRequestDuration,
+  graphqlRequestsTotal,
+  graphqlRequestDuration,
+  databaseQueryDuration,
+  aiRequestsTotal,
+} from './metrics.providers'
+
+@Module({
+  imports: [
+    PrometheusModule.register({
+      path: '/metrics',
+      defaultMetrics: {
+        enabled: true,
+      },
+    }),
+  ],
+  controllers: [MetricsController],
+  providers: [
+    httpRequestsTotal,
+    httpRequestDuration,
+    graphqlRequestsTotal,
+    graphqlRequestDuration,
+    databaseQueryDuration,
+    aiRequestsTotal,
+  ],
+  exports: [
+    httpRequestsTotal,
+    httpRequestDuration,
+    graphqlRequestsTotal,
+    graphqlRequestDuration,
+    databaseQueryDuration,
+    aiRequestsTotal,
+  ],
+})
+export class MetricsModule {}

--- a/apps/api/src/modules/metrics/metrics.module.ts
+++ b/apps/api/src/modules/metrics/metrics.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common'
-import { PrometheusModule } from '@willsoto/nestjs-prometheus'
-import { MetricsController } from './metrics.controller'
+import { Module } from '@nestjs/common';
+import { PrometheusModule } from '@willsoto/nestjs-prometheus';
+import { MetricsController } from './metrics.controller';
 import {
   httpRequestsTotal,
   httpRequestDuration,
@@ -8,7 +8,7 @@ import {
   graphqlRequestDuration,
   databaseQueryDuration,
   aiRequestsTotal,
-} from './metrics.providers'
+} from './metrics.providers';
 
 @Module({
   imports: [

--- a/apps/api/src/modules/metrics/metrics.providers.ts
+++ b/apps/api/src/modules/metrics/metrics.providers.ts
@@ -1,40 +1,43 @@
-import { makeCounterProvider, makeHistogramProvider } from '@willsoto/nestjs-prometheus'
+import {
+  makeCounterProvider,
+  makeHistogramProvider,
+} from '@willsoto/nestjs-prometheus';
 
 export const httpRequestsTotal = makeCounterProvider({
   name: 'http_requests_total',
   help: 'Total number of HTTP requests',
   labelNames: ['method', 'route', 'status_code'],
-})
+});
 
 export const httpRequestDuration = makeHistogramProvider({
   name: 'http_request_duration_seconds',
   help: 'Duration of HTTP requests in seconds',
   labelNames: ['method', 'route', 'status_code'],
   buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
-})
+});
 
 export const graphqlRequestsTotal = makeCounterProvider({
   name: 'graphql_requests_total',
   help: 'Total number of GraphQL requests',
   labelNames: ['operation_type', 'operation_name', 'status'],
-})
+});
 
 export const graphqlRequestDuration = makeHistogramProvider({
   name: 'graphql_request_duration_seconds',
   help: 'Duration of GraphQL requests in seconds',
   labelNames: ['operation_type', 'operation_name'],
   buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
-})
+});
 
 export const databaseQueryDuration = makeHistogramProvider({
   name: 'database_query_duration_seconds',
   help: 'Duration of database queries in seconds',
   labelNames: ['query_type', 'table'],
   buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1],
-})
+});
 
 export const aiRequestsTotal = makeCounterProvider({
   name: 'ai_requests_total',
   help: 'Total number of AI API requests',
   labelNames: ['provider', 'model', 'status'],
-})
+});

--- a/apps/api/src/modules/metrics/metrics.providers.ts
+++ b/apps/api/src/modules/metrics/metrics.providers.ts
@@ -1,0 +1,40 @@
+import { makeCounterProvider, makeHistogramProvider } from '@willsoto/nestjs-prometheus'
+
+export const httpRequestsTotal = makeCounterProvider({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status_code'],
+})
+
+export const httpRequestDuration = makeHistogramProvider({
+  name: 'http_request_duration_seconds',
+  help: 'Duration of HTTP requests in seconds',
+  labelNames: ['method', 'route', 'status_code'],
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+})
+
+export const graphqlRequestsTotal = makeCounterProvider({
+  name: 'graphql_requests_total',
+  help: 'Total number of GraphQL requests',
+  labelNames: ['operation_type', 'operation_name', 'status'],
+})
+
+export const graphqlRequestDuration = makeHistogramProvider({
+  name: 'graphql_request_duration_seconds',
+  help: 'Duration of GraphQL requests in seconds',
+  labelNames: ['operation_type', 'operation_name'],
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+})
+
+export const databaseQueryDuration = makeHistogramProvider({
+  name: 'database_query_duration_seconds',
+  help: 'Duration of database queries in seconds',
+  labelNames: ['query_type', 'table'],
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1],
+})
+
+export const aiRequestsTotal = makeCounterProvider({
+  name: 'ai_requests_total',
+  help: 'Total number of AI API requests',
+  labelNames: ['provider', 'model', 'status'],
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,6 +55,7 @@
     "openai": "^4.23.0",
     "openai-edge": "^1.2.2",
     "prisma": "^5.2.0",
+    "prom-client": "^15.1.3",
     "pusher": "^5.2.0",
     "pusher-js": "^8.4.0-rc2",
     "react": "^18.2.0",

--- a/apps/web/src/app/api/internal/metrics/collect/route.ts
+++ b/apps/web/src/app/api/internal/metrics/collect/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { metricsHelpers } from '@/app/api/metrics/route'
+import { metricsHelpers } from '@/lib/metrics'
 
 export async function POST(request: NextRequest) {
   try {
     const data = await request.json()
     const { method, route, statusCode, duration } = data
-    
+
     // メトリクスを記録
     metricsHelpers.incrementHttpRequests(method, route, statusCode)
     metricsHelpers.recordHttpDuration(method, route, statusCode, duration)
-    
+
     return NextResponse.json({ success: true })
   } catch (error) {
     console.error('Error collecting metrics:', error)

--- a/apps/web/src/app/api/internal/metrics/collect/route.ts
+++ b/apps/web/src/app/api/internal/metrics/collect/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { metricsHelpers } from '@/app/api/metrics/route'
+
+export async function POST(request: NextRequest) {
+  try {
+    const data = await request.json()
+    const { method, route, statusCode, duration } = data
+    
+    // メトリクスを記録
+    metricsHelpers.incrementHttpRequests(method, route, statusCode)
+    metricsHelpers.recordHttpDuration(method, route, statusCode, duration)
+    
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error collecting metrics:', error)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/metrics/route.ts
+++ b/apps/web/src/app/api/metrics/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { register, collectDefaultMetrics, Counter, Histogram, Gauge } from 'prom-client'
+
+// デフォルトメトリクスの収集（CPU、メモリ使用率など）
+collectDefaultMetrics({ register })
+
+// カスタムメトリクスの定義
+const httpRequestsTotal = new Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status_code'],
+  registers: [register]
+})
+
+const httpRequestDuration = new Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'Duration of HTTP requests in seconds',
+  labelNames: ['method', 'route', 'status_code'],
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+  registers: [register]
+})
+
+const activeUsersGauge = new Gauge({
+  name: 'kidoku_active_users',
+  help: 'Number of active users',
+  registers: [register]
+})
+
+const booksRegisteredTotal = new Counter({
+  name: 'kidoku_books_registered_total',
+  help: 'Total number of books registered',
+  registers: [register]
+})
+
+const aiAnalysisRequestsTotal = new Counter({
+  name: 'kidoku_ai_analysis_requests_total',
+  help: 'Total number of AI analysis requests',
+  labelNames: ['ai_provider', 'status'],
+  registers: [register]
+})
+
+// メトリクスエクスポートAPI
+export async function GET(request: NextRequest) {
+  try {
+    // Prometheusフォーマットでメトリクスを返す
+    const metrics = await register.metrics()
+    
+    return new NextResponse(metrics, {
+      status: 200,
+      headers: {
+        'Content-Type': register.contentType,
+      },
+    })
+  } catch (error) {
+    console.error('Error collecting metrics:', error)
+    return new NextResponse('Internal Server Error', { status: 500 })
+  }
+}
+
+// メトリクスヘルパー関数をエクスポート（他のAPIルートから使用可能）
+export const metricsHelpers = {
+  incrementHttpRequests: (method: string, route: string, statusCode: number) => {
+    httpRequestsTotal.inc({ method, route, status_code: statusCode.toString() })
+  },
+  
+  recordHttpDuration: (method: string, route: string, statusCode: number, duration: number) => {
+    httpRequestDuration.observe({ method, route, status_code: statusCode.toString() }, duration)
+  },
+  
+  setActiveUsers: (count: number) => {
+    activeUsersGauge.set(count)
+  },
+  
+  incrementBooksRegistered: () => {
+    booksRegisteredTotal.inc()
+  },
+  
+  incrementAIAnalysisRequests: (provider: string, status: 'success' | 'failure') => {
+    aiAnalysisRequestsTotal.inc({ ai_provider: provider, status })
+  },
+}

--- a/apps/web/src/app/api/metrics/route.ts
+++ b/apps/web/src/app/api/metrics/route.ts
@@ -1,50 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { register, collectDefaultMetrics, Counter, Histogram, Gauge } from 'prom-client'
+import { NextResponse } from 'next/server'
+import { register, collectDefaultMetrics } from 'prom-client'
 
 // デフォルトメトリクスの収集（CPU、メモリ使用率など）
 collectDefaultMetrics({ register })
 
-// カスタムメトリクスの定義
-const httpRequestsTotal = new Counter({
-  name: 'http_requests_total',
-  help: 'Total number of HTTP requests',
-  labelNames: ['method', 'route', 'status_code'],
-  registers: [register]
-})
-
-const httpRequestDuration = new Histogram({
-  name: 'http_request_duration_seconds',
-  help: 'Duration of HTTP requests in seconds',
-  labelNames: ['method', 'route', 'status_code'],
-  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
-  registers: [register]
-})
-
-const activeUsersGauge = new Gauge({
-  name: 'kidoku_active_users',
-  help: 'Number of active users',
-  registers: [register]
-})
-
-const booksRegisteredTotal = new Counter({
-  name: 'kidoku_books_registered_total',
-  help: 'Total number of books registered',
-  registers: [register]
-})
-
-const aiAnalysisRequestsTotal = new Counter({
-  name: 'kidoku_ai_analysis_requests_total',
-  help: 'Total number of AI analysis requests',
-  labelNames: ['ai_provider', 'status'],
-  registers: [register]
-})
-
 // メトリクスエクスポートAPI
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
     // Prometheusフォーマットでメトリクスを返す
     const metrics = await register.metrics()
-    
+
     return new NextResponse(metrics, {
       status: 200,
       headers: {
@@ -55,27 +20,4 @@ export async function GET(request: NextRequest) {
     console.error('Error collecting metrics:', error)
     return new NextResponse('Internal Server Error', { status: 500 })
   }
-}
-
-// メトリクスヘルパー関数をエクスポート（他のAPIルートから使用可能）
-export const metricsHelpers = {
-  incrementHttpRequests: (method: string, route: string, statusCode: number) => {
-    httpRequestsTotal.inc({ method, route, status_code: statusCode.toString() })
-  },
-  
-  recordHttpDuration: (method: string, route: string, statusCode: number, duration: number) => {
-    httpRequestDuration.observe({ method, route, status_code: statusCode.toString() }, duration)
-  },
-  
-  setActiveUsers: (count: number) => {
-    activeUsersGauge.set(count)
-  },
-  
-  incrementBooksRegistered: () => {
-    booksRegisteredTotal.inc()
-  },
-  
-  incrementAIAnalysisRequests: (provider: string, status: 'success' | 'failure') => {
-    aiAnalysisRequestsTotal.inc({ ai_provider: provider, status })
-  },
 }

--- a/apps/web/src/lib/metrics.ts
+++ b/apps/web/src/lib/metrics.ts
@@ -1,0 +1,74 @@
+import { Counter, Histogram, Gauge, register } from 'prom-client'
+
+// カスタムメトリクスの定義
+const httpRequestsTotal = new Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status_code'],
+  registers: [register],
+})
+
+const httpRequestDuration = new Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'Duration of HTTP requests in seconds',
+  labelNames: ['method', 'route', 'status_code'],
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+  registers: [register],
+})
+
+const activeUsersGauge = new Gauge({
+  name: 'kidoku_active_users',
+  help: 'Number of active users',
+  registers: [register],
+})
+
+const booksRegisteredTotal = new Counter({
+  name: 'kidoku_books_registered_total',
+  help: 'Total number of books registered',
+  registers: [register],
+})
+
+const aiAnalysisRequestsTotal = new Counter({
+  name: 'kidoku_ai_analysis_requests_total',
+  help: 'Total number of AI analysis requests',
+  labelNames: ['ai_provider', 'status'],
+  registers: [register],
+})
+
+// メトリクスヘルパー関数
+export const metricsHelpers = {
+  incrementHttpRequests: (
+    method: string,
+    route: string,
+    statusCode: number
+  ) => {
+    httpRequestsTotal.inc({ method, route, status_code: statusCode.toString() })
+  },
+
+  recordHttpDuration: (
+    method: string,
+    route: string,
+    statusCode: number,
+    duration: number
+  ) => {
+    httpRequestDuration.observe(
+      { method, route, status_code: statusCode.toString() },
+      duration
+    )
+  },
+
+  setActiveUsers: (count: number) => {
+    activeUsersGauge.set(count)
+  },
+
+  incrementBooksRegistered: () => {
+    booksRegisteredTotal.inc()
+  },
+
+  incrementAIAnalysisRequests: (
+    provider: string,
+    status: 'success' | 'failure'
+  ) => {
+    aiAnalysisRequestsTotal.inc({ ai_provider: provider, status })
+  },
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from 'next-auth/middleware'
+
+// メトリクス収集用のヘルパー
+async function collectMetrics(request: NextRequest, response: NextResponse) {
+  const startTime = Date.now()
+  const method = request.method
+  const pathname = request.nextUrl.pathname
+  
+  // レスポンスのステータスコードを取得（デフォルトは200）
+  const statusCode = response.status || 200
+  const duration = (Date.now() - startTime) / 1000 // 秒単位
+  
+  // メトリクスAPIにデータを送信（非同期で実行）
+  try {
+    const metricsData = {
+      method,
+      route: pathname,
+      statusCode,
+      duration,
+    }
+    
+    // メトリクス収集は失敗してもアプリケーションに影響しないようにする
+    fetch(`${request.nextUrl.origin}/api/internal/metrics/collect`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(metricsData),
+    }).catch(() => {
+      // エラーは無視
+    })
+  } catch (error) {
+    // メトリクス収集のエラーは無視
+  }
+}
+
+export function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname
+  
+  // メトリクスエンドポイント自体は計測しない
+  if (pathname === '/api/metrics' || pathname === '/api/internal/metrics/collect') {
+    return NextResponse.next()
+  }
+  
+  const response = NextResponse.next()
+  
+  // メトリクス収集（非同期）
+  collectMetrics(request, response)
+  
+  return response
+}
+
+// 認証が必要なパスの設定
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api/auth (auth endpoints)
+     * - api/metrics (metrics endpoint)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!api/auth|api/metrics|_next/static|_next/image|favicon.ico).*)',
+  ],
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,16 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { withAuth } from 'next-auth/middleware'
 
 // メトリクス収集用のヘルパー
 async function collectMetrics(request: NextRequest, response: NextResponse) {
   const startTime = Date.now()
   const method = request.method
   const pathname = request.nextUrl.pathname
-  
+
   // レスポンスのステータスコードを取得（デフォルトは200）
   const statusCode = response.status || 200
   const duration = (Date.now() - startTime) / 1000 // 秒単位
-  
+
   // メトリクスAPIにデータを送信（非同期で実行）
   try {
     const metricsData = {
@@ -19,7 +18,7 @@ async function collectMetrics(request: NextRequest, response: NextResponse) {
       statusCode,
       duration,
     }
-    
+
     // メトリクス収集は失敗してもアプリケーションに影響しないようにする
     fetch(`${request.nextUrl.origin}/api/internal/metrics/collect`, {
       method: 'POST',
@@ -35,17 +34,20 @@ async function collectMetrics(request: NextRequest, response: NextResponse) {
 
 export function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname
-  
+
   // メトリクスエンドポイント自体は計測しない
-  if (pathname === '/api/metrics' || pathname === '/api/internal/metrics/collect') {
+  if (
+    pathname === '/api/metrics' ||
+    pathname === '/api/internal/metrics/collect'
+  ) {
     return NextResponse.next()
   }
-  
+
   const response = NextResponse.next()
-  
+
   // メトリクス収集（非同期）
   collectMetrics(request, response)
-  
+
   return response
 }
 

--- a/apps/web/src/pages/api/ai-summary/exec.ts
+++ b/apps/web/src/pages/api/ai-summary/exec.ts
@@ -3,7 +3,7 @@ import dayjs from 'dayjs'
 import { aiSummaryPrompt } from '@/libs/ai/prompt'
 import cohere from '@/libs/ai/cohere'
 import { RequestCookies } from '@edge-runtime/cookies'
-import { metricsHelpers } from '@/app/api/metrics/route'
+import { metricsHelpers } from '@/lib/metrics'
 
 export const runtime = 'edge'
 
@@ -50,14 +50,15 @@ export default async (req) => {
       }
     })
 
-    let aiAnalysisSuccess = false
-    const response = await cohere.chatStream({
-      model: 'command-r-plus',
-      message: `${aiSummaryPrompt}\n${JSON.stringify(targetBooks)}`,
-    }).catch(error => {
-      metricsHelpers.incrementAIAnalysisRequests('cohere', 'failure')
-      throw error
-    })
+    const response = await cohere
+      .chatStream({
+        model: 'command-r-plus',
+        message: `${aiSummaryPrompt}\n${JSON.stringify(targetBooks)}`,
+      })
+      .catch((error) => {
+        metricsHelpers.incrementAIAnalysisRequests('cohere', 'failure')
+        throw error
+      })
 
     const encoder = new TextEncoder()
     const stream = new ReadableStream({
@@ -98,7 +99,6 @@ export default async (req) => {
                 token,
               },
             })
-            aiAnalysisSuccess = true
             metricsHelpers.incrementAIAnalysisRequests('cohere', 'success')
           }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
     ports:
-      - '3001:3000'
+      - '13000:3000'
     volumes:
       - ./docker/grafana/data:/var/lib/grafana
       - ./docker/grafana/provisioning:/etc/grafana/provisioning
@@ -70,5 +70,5 @@ services:
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
     volumes:
-      - /:/host:ro,rslave
+      - /:/host:ro
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,51 @@ services:
       - "${DB_PORT}:3306"
     volumes:
       - ./docker/mysql/data:/var/lib/mysql
+  
+  prometheus:
+    image: prom/prometheus:v2.48.0
+    container_name: kidoku_prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./docker/prometheus/alert_rules.yml:/etc/prometheus/alert_rules.yml
+      - ./docker/prometheus/data:/prometheus
+    depends_on:
+      - node-exporter
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.2.2
+    container_name: kidoku_grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - '3001:3000'
+    volumes:
+      - ./docker/grafana/data:/var/lib/grafana
+      - ./docker/grafana/provisioning:/etc/grafana/provisioning
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  node-exporter:
+    image: prom/node-exporter:v1.7.0
+    container_name: kidoku_node_exporter
+    ports:
+      - '9100:9100'
+    command:
+      - '--path.rootfs=/host'
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    volumes:
+      - /:/host:ro,rslave
+    restart: unless-stopped

--- a/docker/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docker/grafana/provisioning/dashboards/kidoku-dashboard.json
+++ b/docker/grafana/provisioning/dashboards/kidoku-dashboard.json
@@ -1,0 +1,510 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(http_requests_total[5m])",
+          "legendFormat": "{{method}} {{route}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "95th percentile",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Response Time (95th percentile)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(rate(http_requests_total[5m])) by (status_code)",
+          "legendFormat": "{{status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Response Status Codes",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(rate(kidoku_ai_analysis_requests_total[5m])) by (ai_provider, status)",
+          "legendFormat": "{{ai_provider}} - {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "AI Analysis Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "kidoku_books_registered_total",
+          "legendFormat": "Total Books",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Books Registered",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "rate(node_cpu_seconds_total[5m]) * 100",
+          "legendFormat": "CPU {{cpu}} - {{mode}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["kidoku", "monitoring"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Kidoku Application Dashboard",
+  "uid": "kidoku-main",
+  "version": 0,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -5,5 +5,6 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus:9090
+    uid: prometheus
     isDefault: true
     editable: true

--- a/docker/prometheus/alert_rules.yml
+++ b/docker/prometheus/alert_rules.yml
@@ -1,0 +1,78 @@
+groups:
+  - name: kidoku_alerts
+    interval: 30s
+    rules:
+      # 高いエラーレート（5xx系）
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+            /
+            sum(rate(http_requests_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High error rate detected"
+          description: "Error rate is {{ $value | humanizePercentage }} for the last 5 minutes"
+
+      # 応答時間の悪化
+      - alert: HighResponseTime
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le)
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High response time detected"
+          description: "95th percentile response time is {{ $value }}s for the last 5 minutes"
+
+      # AI API失敗率
+      - alert: AIAnalysisFailureRate
+        expr: |
+          (
+            sum(rate(kidoku_ai_analysis_requests_total{status="failure"}[5m]))
+            /
+            sum(rate(kidoku_ai_analysis_requests_total[5m]))
+          ) > 0.2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High AI analysis failure rate"
+          description: "AI analysis failure rate is {{ $value | humanizePercentage }} for the last 5 minutes"
+
+      # サービスダウン
+      - alert: ServiceDown
+        expr: up{job=~"kidoku-web|kidoku-api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Service {{ $labels.job }} is down"
+          description: "{{ $labels.job }} has been down for more than 1 minute"
+
+      # 高CPU使用率
+      - alert: HighCPUUsage
+        expr: |
+          100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CPU usage detected"
+          description: "CPU usage is {{ $value }}% for the last 5 minutes"
+
+      # 高メモリ使用率
+      - alert: HighMemoryUsage
+        expr: |
+          (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High memory usage detected"
+          description: "Memory usage is {{ $value }}% for the last 5 minutes"

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,40 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: []
+
+rule_files:
+  - "/etc/prometheus/alert_rules.yml"
+
+scrape_configs:
+  # Prometheusのメトリクス
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # Node Exporterのメトリクス（システムメトリクス）
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  # Next.jsアプリケーションのメトリクス
+  - job_name: 'kidoku-web'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+    metrics_path: '/api/metrics'
+
+  # NestJS APIのメトリクス
+  - job_name: 'kidoku-api'
+    static_configs:
+      - targets: ['host.docker.internal:4000']
+    metrics_path: '/metrics'
+
+  # MeiliSearchのメトリクス
+  - job_name: 'meilisearch'
+    static_configs:
+      - targets: ['meilisearch:7700']
+    metrics_path: '/metrics'

--- a/docs/monitoring-quick-reference.md
+++ b/docs/monitoring-quick-reference.md
@@ -17,7 +17,7 @@ docker-compose logs -f prometheus
 
 | サービス | URL | 認証情報 |
 |---------|-----|---------|
-| Grafana | http://localhost:3001 | admin / admin |
+| Grafana | http://localhost:13000 | admin / admin |
 | Prometheus | http://localhost:9090 | なし |
 | Next.js Metrics | http://localhost:3000/api/metrics | なし |
 | NestJS Metrics | http://localhost:4000/metrics | なし |
@@ -169,7 +169,7 @@ httpRequestsTotal.inc({
 
 ## 🔗 便利なリンク
 
-- [Grafanaダッシュボード](http://localhost:3001/d/kidoku-main/kidoku-application-dashboard)
+- [Grafanaダッシュボード](http://localhost:13000/d/kidoku-main/kidoku-application-dashboard)
 - [Prometheusターゲット](http://localhost:9090/targets)
 - [Prometheusアラート](http://localhost:9090/alerts)
 - [メトリクス一覧](http://localhost:9090/graph)
@@ -179,7 +179,7 @@ httpRequestsTotal.inc({
 1. **ダッシュボードのバックアップ**
    ```bash
    # エクスポート
-   curl -s http://admin:admin@localhost:3001/api/dashboards/uid/kidoku-main | jq > dashboard-backup.json
+   curl -s http://admin:admin@localhost:13000/api/dashboards/uid/kidoku-main | jq > dashboard-backup.json
    ```
 
 2. **カスタムアラートのテスト**

--- a/docs/monitoring-quick-reference.md
+++ b/docs/monitoring-quick-reference.md
@@ -1,0 +1,195 @@
+# 監視システムクイックリファレンス
+
+## 🚀 クイックスタート
+
+```bash
+# 監視システムの起動
+docker-compose up -d prometheus grafana node-exporter
+
+# 状態確認
+docker-compose ps
+
+# ログ確認
+docker-compose logs -f prometheus
+```
+
+## 📊 アクセスURL
+
+| サービス | URL | 認証情報 |
+|---------|-----|---------|
+| Grafana | http://localhost:3001 | admin / admin |
+| Prometheus | http://localhost:9090 | なし |
+| Next.js Metrics | http://localhost:3000/api/metrics | なし |
+| NestJS Metrics | http://localhost:4000/metrics | なし |
+
+## 🔍 主要なPrometheusクエリ
+
+### HTTPリクエスト
+```promql
+# リクエストレート（5分平均）
+rate(http_requests_total[5m])
+
+# エラー率
+sum(rate(http_requests_total{status_code=~"5.."}[5m])) / sum(rate(http_requests_total[5m]))
+
+# 95パーセンタイルレスポンスタイム
+histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))
+```
+
+### AI分析
+```promql
+# AI分析成功率
+sum(rate(kidoku_ai_analysis_requests_total{status="success"}[5m])) / sum(rate(kidoku_ai_analysis_requests_total[5m]))
+
+# プロバイダー別リクエスト数
+sum by (ai_provider) (rate(kidoku_ai_analysis_requests_total[5m]))
+```
+
+### システムメトリクス
+```promql
+# CPU使用率
+100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+
+# メモリ使用率
+(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100
+```
+
+## 📝 メトリクス追加の例
+
+### Next.js
+```typescript
+// apps/web/src/lib/metrics.ts に追加
+const myCustomMetric = new Counter({
+  name: 'kidoku_my_feature_total',
+  help: 'Description of my metric',
+  labelNames: ['status'],
+  registers: [register],
+})
+
+export const metricsHelpers = {
+  // 既存のヘルパー...
+  incrementMyFeature: (status: string) => {
+    myCustomMetric.inc({ status })
+  },
+}
+
+// 使用例
+import { metricsHelpers } from '@/lib/metrics'
+metricsHelpers.incrementMyFeature('success')
+```
+
+### NestJS
+```typescript
+// メトリクスプロバイダーを追加
+export const myFeatureCounter = makeCounterProvider({
+  name: 'my_feature_total',
+  help: 'My feature counter',
+  labelNames: ['action'],
+})
+
+// モジュールに追加
+providers: [
+  // 既存のプロバイダー...
+  myFeatureCounter,
+]
+
+// サービスで使用
+constructor(
+  @InjectMetric('my_feature_total')
+  private readonly myFeatureCounter: Counter<string>,
+) {}
+
+doSomething() {
+  this.myFeatureCounter.inc({ action: 'create' })
+}
+```
+
+## 🔧 よく使うコマンド
+
+```bash
+# コンテナの再起動
+docker-compose restart prometheus grafana
+
+# 設定ファイルの再読み込み（Prometheus）
+docker-compose exec prometheus kill -HUP 1
+
+# Grafanaパスワードリセット
+docker-compose exec grafana grafana-cli admin reset-admin-password newpassword
+
+# メトリクスの手動確認
+curl -s http://localhost:3000/api/metrics | grep kidoku
+curl -s http://localhost:4000/metrics | grep http_
+
+# Prometheusのクエリ実行
+curl -s 'http://localhost:9090/api/v1/query?query=up'
+```
+
+## 🐛 トラブルシューティング
+
+### メトリクスが表示されない
+1. ターゲットの状態確認: http://localhost:9090/targets
+2. メトリクスエンドポイントの確認: `curl http://localhost:3000/api/metrics`
+3. Prometheusログ確認: `docker-compose logs prometheus`
+
+### Grafanaダッシュボードが空
+1. データソース接続確認: Settings > Data Sources
+2. 時間範囲の確認（右上のタイムピッカー）
+3. クエリの確認: ダッシュボード編集モード
+
+### 高いメモリ使用
+1. メトリクスのカーディナリティ確認
+2. 不要なラベルの削除
+3. スクレイプ間隔の調整
+
+## 📈 パフォーマンスチューニング
+
+### Prometheus
+```yaml
+# prometheus.yml
+global:
+  scrape_interval: 30s      # デフォルト15s → 30sに変更
+  scrape_timeout: 10s       # タイムアウト設定
+  evaluation_interval: 30s  # アラート評価間隔
+```
+
+### メトリクスの最適化
+```typescript
+// ❌ 悪い例：高カーディナリティ
+httpRequestsTotal.inc({ 
+  user_id: userId,  // ユニークな値が多い
+  timestamp: Date.now()  // 常に異なる値
+})
+
+// ✅ 良い例：低カーディナリティ
+httpRequestsTotal.inc({ 
+  method: 'GET',
+  status: 'success'
+})
+```
+
+## 🔗 便利なリンク
+
+- [Grafanaダッシュボード](http://localhost:3001/d/kidoku-main/kidoku-application-dashboard)
+- [Prometheusターゲット](http://localhost:9090/targets)
+- [Prometheusアラート](http://localhost:9090/alerts)
+- [メトリクス一覧](http://localhost:9090/graph)
+
+## 💡 Tips
+
+1. **ダッシュボードのバックアップ**
+   ```bash
+   # エクスポート
+   curl -s http://admin:admin@localhost:3001/api/dashboards/uid/kidoku-main | jq > dashboard-backup.json
+   ```
+
+2. **カスタムアラートのテスト**
+   ```promql
+   # Prometheusコンソールでクエリをテスト
+   vector(1) > 0  # 常にtrueになるテストクエリ
+   ```
+
+3. **メトリクスのデバッグ**
+   ```bash
+   # 特定のメトリクスを検索
+   curl -s http://localhost:3000/api/metrics | grep -E "^kidoku_"
+   ```

--- a/docs/monitoring-setup.md
+++ b/docs/monitoring-setup.md
@@ -1,0 +1,128 @@
+# 監視システムセットアップガイド
+
+Kidokuの監視システムは、Prometheus + Grafanaを使用してアプリケーションのパフォーマンスと可用性を監視します。
+
+## 構成要素
+
+- **Prometheus**: メトリクス収集・保存
+- **Grafana**: 可視化・ダッシュボード
+- **Node Exporter**: システムメトリクス収集
+- **アプリケーションメトリクス**: Next.js/NestJSのカスタムメトリクス
+
+## セットアップ手順
+
+### 1. 監視システムの起動
+
+```bash
+# Docker Composeで全サービスを起動
+docker-compose up -d
+
+# 監視サービスのみ起動する場合
+docker-compose up -d prometheus grafana node-exporter
+```
+
+### 2. 各サービスへのアクセス
+
+- **Grafana**: http://localhost:3001
+  - 初期ユーザー名: `admin`
+  - 初期パスワード: `admin`
+- **Prometheus**: http://localhost:9090
+- **Next.js メトリクス**: http://localhost:3000/api/metrics
+- **NestJS メトリクス**: http://localhost:4000/metrics
+
+### 3. Grafanaダッシュボード
+
+起動時に自動的に以下のダッシュボードがプロビジョニングされます：
+
+- **Kidoku Application Dashboard**: アプリケーション全体の監視
+  - HTTPリクエストレート
+  - レスポンスタイム（95パーセンタイル）
+  - ステータスコード分布
+  - AI分析リクエスト
+  - 登録された本の総数
+  - CPU使用率
+
+## 収集されるメトリクス
+
+### システムメトリクス
+- CPU使用率
+- メモリ使用率
+- ディスク使用率
+- ネットワークI/O
+
+### アプリケーションメトリクス
+
+#### Next.js
+- `http_requests_total`: HTTPリクエスト総数
+- `http_request_duration_seconds`: リクエスト処理時間
+- `kidoku_active_users`: アクティブユーザー数
+- `kidoku_books_registered_total`: 登録された本の総数
+- `kidoku_ai_analysis_requests_total`: AI分析リクエスト数
+
+#### NestJS API
+- `http_requests_total`: HTTPリクエスト総数
+- `http_request_duration_seconds`: リクエスト処理時間
+- `graphql_requests_total`: GraphQLリクエスト総数
+- `graphql_request_duration_seconds`: GraphQLリクエスト処理時間
+- `database_query_duration_seconds`: データベースクエリ実行時間
+- `ai_requests_total`: AI APIリクエスト数
+
+## アラート設定
+
+以下のアラートが設定されています：
+
+1. **HighErrorRate**: 5xxエラー率が5%を超えた場合
+2. **HighResponseTime**: 95パーセンタイルレスポンスタイムが1秒を超えた場合
+3. **AIAnalysisFailureRate**: AI分析失敗率が20%を超えた場合
+4. **ServiceDown**: サービスがダウンした場合
+5. **HighCPUUsage**: CPU使用率が80%を超えた場合
+6. **HighMemoryUsage**: メモリ使用率が85%を超えた場合
+
+## カスタムメトリクスの追加
+
+### Next.jsでメトリクスを追加する場合
+
+```typescript
+import { metricsHelpers } from '@/app/api/metrics/route'
+
+// カウンターをインクリメント
+metricsHelpers.incrementBooksRegistered()
+
+// AI分析リクエストを記録
+metricsHelpers.incrementAIAnalysisRequests('openai', 'success')
+```
+
+### NestJSでメトリクスを追加する場合
+
+```typescript
+import { InjectMetric } from '@willsoto/nestjs-prometheus'
+import { Counter } from 'prom-client'
+
+constructor(
+  @InjectMetric('custom_metric_name')
+  private readonly customMetric: Counter<string>,
+) {}
+
+// メトリクスを記録
+this.customMetric.inc({ label: 'value' })
+```
+
+## トラブルシューティング
+
+### Prometheusがメトリクスを取得できない場合
+
+1. ターゲットの状態を確認: http://localhost:9090/targets
+2. `docker-compose logs prometheus` でエラーログを確認
+3. ファイアウォール設定を確認
+
+### Grafanaダッシュボードが表示されない場合
+
+1. データソースの接続を確認: Grafana > Configuration > Data Sources
+2. Prometheusが正常に動作しているか確認
+3. `docker-compose restart grafana` で再起動
+
+### メトリクスが収集されない場合
+
+1. アプリケーションが正常に起動しているか確認
+2. `/api/metrics` エンドポイントが応答するか確認
+3. Prometheusの設定でスクレイプ間隔を確認

--- a/docs/monitoring-setup.md
+++ b/docs/monitoring-setup.md
@@ -23,7 +23,7 @@ docker-compose up -d prometheus grafana node-exporter
 
 ### 2. 各サービスへのアクセス
 
-- **Grafana**: http://localhost:3001
+- **Grafana**: http://localhost:13000
   - 初期ユーザー名: `admin`
   - 初期パスワード: `admin`
 - **Prometheus**: http://localhost:9090
@@ -108,6 +108,24 @@ this.customMetric.inc({ label: 'value' })
 ```
 
 ## トラブルシューティング
+
+### Grafanaがデータソースを見つけられない場合
+
+1. Prometheusコンテナが起動しているか確認
+   ```bash
+   docker-compose ps prometheus
+   ```
+
+2. データソース設定にUIDが含まれているか確認
+   ```bash
+   cat docker/grafana/provisioning/datasources/prometheus.yml
+   ```
+   `uid: prometheus` が設定されていることを確認
+
+3. Grafanaを再起動
+   ```bash
+   docker-compose restart grafana
+   ```
 
 ### Prometheusがメトリクスを取得できない場合
 

--- a/docs/monitoring-system-implementation.md
+++ b/docs/monitoring-system-implementation.md
@@ -23,7 +23,7 @@ Kidokuの監視システムは、Prometheus + Grafanaを基盤として構築さ
                                  │
                          ┌───────▼────────┐
                          │    Grafana     │
-                         │     :3001      │
+                         │     :13000      │
                          └────────────────┘
 ```
 
@@ -57,7 +57,7 @@ scrape_configs:
 メトリクスの可視化とダッシュボード機能を提供します。
 
 **アクセス情報**:
-- URL: http://localhost:3001
+- URL: http://localhost:13000
 - 初期ユーザー名: admin
 - 初期パスワード: admin
 

--- a/docs/monitoring-system-implementation.md
+++ b/docs/monitoring-system-implementation.md
@@ -1,0 +1,308 @@
+# 監視システム実装ガイド
+
+このドキュメントでは、Kidokuアプリケーションに実装した監視システムの詳細について説明します。
+
+## 概要
+
+Kidokuの監視システムは、Prometheus + Grafanaを基盤として構築されており、アプリケーションのパフォーマンス、可用性、エラー率などを可視化・監視します。
+
+## アーキテクチャ
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   Next.js App   │     │   NestJS API    │     │  Node Exporter  │
+│ /api/metrics    │     │    /metrics     │     │   :9100         │
+└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
+         │                       │                         │
+         └───────────────────────┴─────────────────────────┘
+                                 │
+                         ┌───────▼────────┐
+                         │   Prometheus   │
+                         │     :9090      │
+                         └───────┬────────┘
+                                 │
+                         ┌───────▼────────┐
+                         │    Grafana     │
+                         │     :3001      │
+                         └────────────────┘
+```
+
+## コンポーネント詳細
+
+### 1. Prometheus
+
+メトリクスの収集と保存を担当するモニタリングシステムです。
+
+**設定ファイル**: `docker/prometheus/prometheus.yml`
+
+```yaml
+global:
+  scrape_interval: 15s      # メトリクス収集間隔
+  evaluation_interval: 15s   # ルール評価間隔
+
+scrape_configs:
+  - job_name: 'kidoku-web'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+    metrics_path: '/api/metrics'
+    
+  - job_name: 'kidoku-api'
+    static_configs:
+      - targets: ['host.docker.internal:4000']
+    metrics_path: '/metrics'
+```
+
+### 2. Grafana
+
+メトリクスの可視化とダッシュボード機能を提供します。
+
+**アクセス情報**:
+- URL: http://localhost:3001
+- 初期ユーザー名: admin
+- 初期パスワード: admin
+
+**自動プロビジョニング**:
+- データソース: `docker/grafana/provisioning/datasources/prometheus.yml`
+- ダッシュボード: `docker/grafana/provisioning/dashboards/kidoku-dashboard.json`
+
+### 3. Node Exporter
+
+システムレベルのメトリクス（CPU、メモリ、ディスク使用率など）を収集します。
+
+## 実装詳細
+
+### Next.js アプリケーション
+
+#### 1. メトリクスエンドポイント
+
+**ファイル**: `apps/web/src/app/api/metrics/route.ts`
+
+```typescript
+import { NextResponse } from 'next/server'
+import { register, collectDefaultMetrics } from 'prom-client'
+
+// デフォルトメトリクスの収集
+collectDefaultMetrics({ register })
+
+export async function GET() {
+  const metrics = await register.metrics()
+  return new NextResponse(metrics, {
+    headers: {
+      'Content-Type': register.contentType,
+    },
+  })
+}
+```
+
+#### 2. カスタムメトリクス
+
+**ファイル**: `apps/web/src/lib/metrics.ts`
+
+実装されているメトリクス:
+- `http_requests_total`: HTTPリクエストの総数
+- `http_request_duration_seconds`: リクエスト処理時間
+- `kidoku_active_users`: アクティブユーザー数
+- `kidoku_books_registered_total`: 登録された本の総数
+- `kidoku_ai_analysis_requests_total`: AI分析リクエスト数
+
+#### 3. ミドルウェア
+
+**ファイル**: `apps/web/src/middleware.ts`
+
+HTTPリクエストを自動的に計測し、メトリクスを収集します。
+
+### NestJS API
+
+#### 1. メトリクスモジュール
+
+**ファイル**: `apps/api/src/modules/metrics/metrics.module.ts`
+
+```typescript
+@Module({
+  imports: [
+    PrometheusModule.register({
+      path: '/metrics',
+      defaultMetrics: {
+        enabled: true,
+      },
+    }),
+  ],
+  // ...
+})
+```
+
+#### 2. メトリクスインターセプター
+
+**ファイル**: `apps/api/src/common/interceptors/metrics.interceptor.ts`
+
+すべてのHTTPリクエストを自動的に計測します。
+
+#### 3. カスタムメトリクス
+
+実装されているメトリクス:
+- `graphql_requests_total`: GraphQLリクエスト数
+- `graphql_request_duration_seconds`: GraphQL処理時間
+- `database_query_duration_seconds`: データベースクエリ時間
+- `ai_requests_total`: AI APIリクエスト数
+
+## ダッシュボード
+
+### Kidoku Application Dashboard
+
+以下のパネルが含まれています:
+
+1. **HTTP Request Rate**: HTTPリクエストレート
+2. **Response Time (95th percentile)**: 95パーセンタイルレスポンスタイム
+3. **Response Status Codes**: ステータスコード分布
+4. **AI Analysis Requests**: AI分析リクエスト
+5. **Total Books Registered**: 登録された本の総数
+6. **CPU Usage**: CPU使用率
+
+## アラート設定
+
+**ファイル**: `docker/prometheus/alert_rules.yml`
+
+設定されているアラート:
+
+| アラート名 | 条件 | 重要度 |
+|----------|------|-------|
+| HighErrorRate | 5xxエラー率 > 5% | critical |
+| HighResponseTime | 95%タイル応答時間 > 1秒 | warning |
+| AIAnalysisFailureRate | AI分析失敗率 > 20% | warning |
+| ServiceDown | サービス停止 | critical |
+| HighCPUUsage | CPU使用率 > 80% | warning |
+| HighMemoryUsage | メモリ使用率 > 85% | warning |
+
+## 使用方法
+
+### メトリクスの追加
+
+#### Next.jsでカスタムメトリクスを追加する場合:
+
+```typescript
+import { metricsHelpers } from '@/lib/metrics'
+
+// 本の登録時
+metricsHelpers.incrementBooksRegistered()
+
+// AI分析実行時
+try {
+  const result = await analyzeWithAI()
+  metricsHelpers.incrementAIAnalysisRequests('openai', 'success')
+} catch (error) {
+  metricsHelpers.incrementAIAnalysisRequests('openai', 'failure')
+  throw error
+}
+```
+
+#### NestJSでカスタムメトリクスを追加する場合:
+
+```typescript
+import { InjectMetric } from '@willsoto/nestjs-prometheus'
+import { Counter } from 'prom-client'
+
+@Injectable()
+export class MyService {
+  constructor(
+    @InjectMetric('my_custom_metric')
+    private readonly customMetric: Counter<string>,
+  ) {}
+
+  async doSomething() {
+    this.customMetric.inc({ label: 'value' })
+  }
+}
+```
+
+### 新しいダッシュボードの作成
+
+1. Grafanaにログイン
+2. Create > Dashboard
+3. Add panel
+4. Query設定でPrometheusを選択
+5. メトリクスを選択して可視化
+
+### アラートの追加
+
+1. `docker/prometheus/alert_rules.yml`を編集
+2. 新しいアラートルールを追加
+3. Prometheusを再起動
+
+## トラブルシューティング
+
+### メトリクスが表示されない
+
+1. エンドポイントの確認
+   ```bash
+   curl http://localhost:3000/api/metrics
+   curl http://localhost:4000/metrics
+   ```
+
+2. Prometheusターゲットの状態確認
+   - http://localhost:9090/targets
+
+3. ログの確認
+   ```bash
+   docker-compose logs prometheus
+   docker-compose logs grafana
+   ```
+
+### Grafanaにログインできない
+
+初期パスワードをリセット:
+```bash
+docker-compose exec grafana grafana-cli admin reset-admin-password newpassword
+```
+
+### メトリクスの保存期間
+
+デフォルトでは15日間保存されます。変更する場合は、Prometheusの起動コマンドに以下を追加:
+```yaml
+command:
+  - '--storage.tsdb.retention.time=30d'
+```
+
+## ベストプラクティス
+
+### 1. メトリクス命名規則
+
+- 単位を含める: `_seconds`, `_bytes`, `_total`
+- アンダースコアで単語を区切る
+- 名前空間を使用: `kidoku_feature_metric`
+
+### 2. ラベルの使用
+
+- カーディナリティに注意（ユニークな値が多すぎない）
+- 固定的な値を使用（status: "success"/"failure"など）
+
+### 3. メトリクスタイプの選択
+
+- カウンター: 増加のみする値（リクエスト数など）
+- ゲージ: 増減する値（アクティブユーザー数など）
+- ヒストグラム: 分布を測定（レスポンスタイムなど）
+
+### 4. パフォーマンスへの配慮
+
+- メトリクス収集は非同期で実行
+- エラーが発生してもアプリケーションに影響しない
+- 適切なスクレイプ間隔の設定（デフォルト15秒）
+
+## セキュリティ考慮事項
+
+1. **アクセス制限**: 本番環境ではメトリクスエンドポイントへのアクセスを制限
+2. **認証**: Grafanaのデフォルトパスワードを変更
+3. **機密情報**: メトリクスに個人情報やセキュリティ情報を含めない
+
+## 今後の拡張可能性
+
+1. **アラートマネージャー**: Prometheusアラートの通知設定
+2. **ログ収集**: Loki等によるログ管理
+3. **分散トレーシング**: Jaeger等によるトレース収集
+4. **カスタムエクスポーター**: 外部サービスのメトリクス収集
+
+## 参考リンク
+
+- [Prometheus Documentation](https://prometheus.io/docs/)
+- [Grafana Documentation](https://grafana.com/docs/)
+- [prom-client Documentation](https://github.com/siimon/prom-client)
+- [@willsoto/nestjs-prometheus](https://github.com/willsoto/nestjs-prometheus)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.0(@nestjs/common@11.1.0(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.0)
+      '@willsoto/nestjs-prometheus':
+        specifier: ^6.0.2
+        version: 6.0.2(@nestjs/common@11.1.0(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -58,7 +61,7 @@ importers:
         version: 0.14.2
       drizzle-orm:
         specifier: ^0.43.1
-        version: 0.43.1(@prisma/client@5.22.0(prisma@5.22.0))(mysql2@3.14.1)(prisma@5.22.0)
+        version: 0.43.1(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mysql2@3.14.1)(prisma@5.22.0)
       graphql:
         specifier: ^16.11.0
         version: 16.11.0
@@ -71,6 +74,9 @@ importers:
       passport-jwt:
         specifier: ^4.0.1
         version: 4.0.1
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -176,7 +182,7 @@ importers:
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.20)(react@18.3.1))(@types/react@18.3.20)(react@18.3.1)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.11(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.11(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@prisma/client':
         specifier: ^5.2.0
         version: 5.22.0(prisma@5.22.0)
@@ -191,7 +197,7 @@ importers:
         version: 2.4.0
       '@vercel/analytics':
         specifier: ^1.2.2
-        version: 1.5.0(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.19)(vue@3.5.13(typescript@4.9.5))
+        version: 1.5.0(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.19)(vue@3.5.13(typescript@4.9.5))
       '@vercel/blob':
         specifier: ^0.13.0
         version: 0.13.1
@@ -242,16 +248,16 @@ importers:
         version: 10.0.1
       next:
         specifier: ^14.1.0
-        version: 14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.23.1
-        version: 4.24.11(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-compose-plugins:
         specifier: ^2.2.1
         version: 2.2.1
       next-seo:
         specifier: ^5.8.0
-        version: 5.15.0(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.15.0(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       node-fetch:
         specifier: ^3.2.10
         version: 3.3.2
@@ -267,6 +273,9 @@ importers:
       prisma:
         specifier: ^5.2.0
         version: 5.22.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       pusher:
         specifier: ^5.2.0
         version: 5.2.0
@@ -2117,6 +2126,10 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
@@ -3029,6 +3042,12 @@ packages:
     resolution: {integrity: sha512-D+OwTEunoQhVHVToD80dPhfz9xgPLqJyEA3F5jCRM14A2u8tBBQVdZekqfqx6ZAfZ+POT4Hb0dn601UKMsvADw==}
     engines: {node: '>=16.0.0'}
 
+  '@willsoto/nestjs-prometheus@6.0.2':
+    resolution: {integrity: sha512-ePyLZYdIrOOdlOWovzzMisIgviXqhPVzFpSMKNNhn6xajhRHeBsjAzSdpxZTc6pnjR9hw1lNAHyKnKl7lAPaVg==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      prom-client: ^15.0.0
+
   '@wry/caches@1.0.1':
     resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
     engines: {node: '>=8'}
@@ -3427,6 +3446,9 @@ packages:
 
   binary@0.3.0:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -6741,6 +6763,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -7583,6 +7609,9 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terser-webpack-plugin@5.3.14:
     resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
@@ -9861,10 +9890,10 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.0(@nestjs/common@11.1.0(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.0)
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.11(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.11(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@prisma/client': 5.22.0(prisma@5.22.0)
-      next-auth: 4.24.11(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-auth: 4.24.11(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   '@next/bundle-analyzer@12.3.7':
     dependencies:
@@ -10012,6 +10041,8 @@ snapshots:
       '@octokit/openapi-types': 18.1.1
 
   '@one-ini/wasm@0.1.1': {}
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@panva/hkdf@1.2.1': {}
 
@@ -10878,9 +10909,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.6.6':
     optional: true
 
-  '@vercel/analytics@1.5.0(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.19)(vue@3.5.13(typescript@4.9.5))':
+  '@vercel/analytics@1.5.0(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.19)(vue@3.5.13(typescript@4.9.5))':
     optionalDependencies:
-      next: 14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       svelte: 4.2.19
       vue: 3.5.13(typescript@4.9.5)
@@ -11034,6 +11065,11 @@ snapshots:
   '@whatwg-node/promise-helpers@1.3.1':
     dependencies:
       tslib: 2.8.1
+
+  '@willsoto/nestjs-prometheus@6.0.2(@nestjs/common@11.1.0(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)':
+    dependencies:
+      '@nestjs/common': 11.1.0(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      prom-client: 15.1.3
 
   '@wry/caches@1.0.1':
     dependencies:
@@ -11494,6 +11530,8 @@ snapshots:
     dependencies:
       buffers: 0.1.1
       chainsaw: 0.1.0
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -12232,8 +12270,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.43.1(@prisma/client@5.22.0(prisma@5.22.0))(mysql2@3.14.1)(prisma@5.22.0):
+  drizzle-orm@0.43.1(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mysql2@3.14.1)(prisma@5.22.0):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@prisma/client': 5.22.0(prisma@5.22.0)
       mysql2: 3.14.1
       prisma: 5.22.0
@@ -14795,13 +14834,13 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@4.24.11(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.11(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.27.0
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.26.5
@@ -14812,13 +14851,13 @@ snapshots:
 
   next-compose-plugins@2.2.1: {}
 
-  next-seo@5.15.0(next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-seo@5.15.0(next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      next: 14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@14.2.28(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.28(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.28
       '@swc/helpers': 0.5.5
@@ -14839,6 +14878,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.28
       '@next/swc-win32-ia32-msvc': 14.2.28
       '@next/swc-win32-x64-msvc': 14.2.28
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -15279,6 +15319,11 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
 
   prompts@2.4.2:
     dependencies:
@@ -16378,6 +16423,10 @@ snapshots:
       b4a: 1.6.7
       fast-fifo: 1.3.2
       streamx: 2.22.0
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   terser-webpack-plugin@5.3.14(@swc/core@1.11.22)(esbuild@0.25.3)(webpack@5.99.6(@swc/core@1.11.22)(esbuild@0.25.3)):
     dependencies:


### PR DESCRIPTION
## Summary
- Docker ComposeにGrafana、Prometheus、Node Exporterを追加
- Next.jsとNestJS APIにメトリクスエクスポート機能を実装
- Grafanaダッシュボードとアラートルールを設定

## 実装内容

### 1. インフラストラクチャ
- **Docker Compose**: Prometheus、Grafana、Node Exporterのコンテナを追加
- **ポート設定**: Grafana (3001)、Prometheus (9090)、Node Exporter (9100)

### 2. メトリクス収集
#### Next.js
- `/api/metrics`エンドポイントでPrometheusフォーマットのメトリクスを公開
- カスタムメトリクス: HTTPリクエスト数、AI分析リクエスト、本の登録数など
- ミドルウェアによる自動メトリクス収集

#### NestJS API
- `/metrics`エンドポイントでメトリクスを公開
- @willsoto/nestjs-prometheusを使用
- インターセプターによるHTTP/GraphQLメトリクスの自動収集

### 3. 可視化とアラート
- Grafanaダッシュボードの自動プロビジョニング
- 主要メトリクスの可視化（リクエスト数、レスポンスタイム、エラー率等）
- Prometheusアラートルール（高エラー率、サービスダウン等）

### 4. ドキュメント
- 監視システムのセットアップと使用方法を文書化

## Test plan
- [ ] `docker-compose up -d`で監視サービスが起動することを確認
- [ ] http://localhost:3001 でGrafanaにアクセスできることを確認（admin/admin）
- [ ] http://localhost:3000/api/metrics でNext.jsのメトリクスが表示されることを確認
- [ ] http://localhost:4000/metrics でNestJS APIのメトリクスが表示されることを確認
- [ ] Grafanaダッシュボードでメトリクスが正しく表示されることを確認
- [ ] アプリケーションを使用してメトリクスが更新されることを確認

Closes #10