### PR TITLE
本を登録する際、登録できているのに失敗と出てしまうのを修正

### DIFF
--- a/apps/web/src/pages/api/batch/meilisearch.ts
+++ b/apps/web/src/pages/api/batch/meilisearch.ts
@@ -23,20 +23,22 @@ export default async function handler(
         sheet: { select: { name: true } },
       },
     })
-    const documents = books.map((book) => {
-      const { id, title, author, image, memo, is_public_memo, user, sheet } =
-        book
-      return {
-        id,
-        title,
-        author,
-        image,
-        memo: is_public_memo ? memo : '',
-        username: user.name,
-        userImage: user.image,
-        sheet: sheet.name,
-      }
-    })
+    const documents = books
+      .filter((book) => book.sheet !== null) // sheetがnullのレコードを除外
+      .map((book) => {
+        const { id, title, author, image, memo, is_public_memo, user, sheet } =
+          book
+        return {
+          id,
+          title,
+          author,
+          image,
+          memo: is_public_memo ? memo : '',
+          username: user.name,
+          userImage: user.image,
+          sheet: sheet.name,
+        }
+      })
     const result = await addDocuments('books', documents)
     console.log(result)
     return response.status(200).json({ result: true })

--- a/apps/web/src/pages/api/books/index.ts
+++ b/apps/web/src/pages/api/books/index.ts
@@ -31,7 +31,8 @@ async function updateMeiliSearchDocuments() {
     const documents = books
       .filter((book) => book.sheet !== null) // sheetがnullのレコードを除外
       .map((book) => {
-        const { id, title, author, image, memo, is_public_memo, user, sheet } = book
+        const { id, title, author, image, memo, is_public_memo, user, sheet } =
+          book
         return {
           id,
           title,

--- a/apps/web/src/pages/api/books/index.ts
+++ b/apps/web/src/pages/api/books/index.ts
@@ -15,33 +15,41 @@ export const config = {
 }
 
 async function updateMeiliSearchDocuments() {
-  const books = await prisma.books.findMany({
-    select: {
-      id: true,
-      title: true,
-      author: true,
-      image: true,
-      is_public_memo: true,
-      memo: true,
-      user: { select: { name: true, image: true } },
-      sheet: { select: { name: true } },
-    },
-  })
-  const documents = books.map((book) => {
-    const { id, title, author, image, memo, is_public_memo, user, sheet } = book
-    return {
-      id,
-      title,
-      author,
-      image,
-      memo: is_public_memo ? memo : '',
-      username: user.name,
-      userImage: user.image,
-      sheet: sheet.name,
-    }
-  })
-  const result = await addDocuments('books', documents)
-  return result
+  try {
+    const books = await prisma.books.findMany({
+      select: {
+        id: true,
+        title: true,
+        author: true,
+        image: true,
+        is_public_memo: true,
+        memo: true,
+        user: { select: { name: true, image: true } },
+        sheet: { select: { name: true } },
+      },
+    })
+    const documents = books
+      .filter((book) => book.sheet !== null) // sheetがnullのレコードを除外
+      .map((book) => {
+        const { id, title, author, image, memo, is_public_memo, user, sheet } = book
+        return {
+          id,
+          title,
+          author,
+          image,
+          memo: is_public_memo ? memo : '',
+          username: user.name,
+          userImage: user.image,
+          sheet: sheet.name,
+        }
+      })
+    const result = await addDocuments('books', documents)
+    return result
+  } catch (error) {
+    console.error('updateMeiliSearchDocuments error:', error)
+    // エラーが発生してもAPIレスポンスは継続
+    return null
+  }
 }
 
 export default async (req, res) => {


### PR DESCRIPTION
## 概要
本番環境で本を登録する際に発生していた「Field sheet is required to return data, got null instead」エラーを修正しました。

## 問題
- `prisma.books.findMany()`でsheetリレーションを含めた際、一部のbooksレコードのsheet_idに対応するsheetsレコードが存在しない
- Prismaスキーマではsheet_idは必須フィールドだが、データベースに不整合が存在していた

## 修正内容
### 1. `/pages/api/books/index.ts`
- `updateMeiliSearchDocuments`関数にtry-catchでエラーハンドリングを追加
- sheetがnullのレコードをフィルタリングで除外
- エラーが発生してもAPI処理は継続するように変更

### 2. `/pages/api/batch/meilisearch.ts`
- 同様にsheetがnullのレコードをフィルタリングで除外

## テスト
- ビルドとLintは成功
- 本番環境でのエラーが解消されることを確認予定

## 影響範囲
- 本の登録処理
- MeiliSearch検索インデックスの更新処理